### PR TITLE
Add ical Link

### DIFF
--- a/api/.env.dev
+++ b/api/.env.dev
@@ -11,5 +11,6 @@ DB_USER_PASSWORD=secret_password
 DB_HOST=localhost
 DB_PORT=5432
 
+PAD_OWNER_PASS=ctfnote
 
 WEB_PORT=3000

--- a/api/.lintstagedrc.json
+++ b/api/.lintstagedrc.json
@@ -1,3 +1,3 @@
 {
-    "*.{js,ts,vue,graphql}": "eslint --fix "
+    "*.{js,ts,vue}": "eslint --fix "
 }

--- a/api/migrations/41-ical-link.sql
+++ b/api/migrations/41-ical-link.sql
@@ -1,0 +1,5 @@
+ALTER TABLE ctfnote.settings
+  ADD COLUMN "ical_password" TEXT DEFAULT encode(gen_random_bytes(16), 'hex');
+
+GRANT SELECT ("ical_password") ON ctfnote.settings TO user_guest;
+

--- a/api/package.json
+++ b/api/package.json
@@ -29,7 +29,8 @@
     "graphql-upload": "^12.0.0",
     "postgraphile": "^4.11.0",
     "postgraphile-plugin-connection-filter": "^2.1.1",
-    "postgres-migrations": "^5.3.0"
+    "postgres-migrations": "^5.3.0",
+    "slugify": "^1.6.5"
   },
   "devDependencies": {
     "@types/express": "^4.17.11",

--- a/api/package.json
+++ b/api/package.json
@@ -27,6 +27,7 @@
     "graphile-utils": "^4.11.2",
     "graphql": "^15.6.1",
     "graphql-upload": "^12.0.0",
+    "ical-generator": "^3.2.1",
     "postgraphile": "^4.11.0",
     "postgraphile-plugin-connection-filter": "^2.1.1",
     "postgres-migrations": "^5.3.0",

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -78,11 +78,7 @@ function createOptions() {
 
 function createApp(postgraphileOptions: PostGraphileOptions) {
   const pool = new Pool({
-    host: config.db.host,
-    database: config.db.database,
-    port: config.db.port,
-    user: config.db.admin.login,
-    password: config.db.admin.password,
+    connectionString: getDbUrl("user"),
   });
 
   const app = express();

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -16,6 +16,8 @@ import passwordCheck from "./plugins/passwordCheck";
 import importCtfPlugin from "./plugins/importCtf";
 import uploadLogoPlugin from "./plugins/uploadLogo";
 import uploadScalar from "./plugins/uploadScalar";
+import { Pool } from "pg";
+import { icalRoute } from "./routes/ical";
 
 function getDbUrl(role: "user" | "admin") {
   const login = config.db[role].login;
@@ -53,7 +55,8 @@ function createOptions() {
     legacyRelations: "omit" as const,
     async additionalGraphQLContextFromRequest(req, res) {
       return {
-        setHeader: (name: string, value: string | number) => res.setHeader(name, value)
+        setHeader: (name: string, value: string | number) =>
+          res.setHeader(name, value),
       };
     },
   };
@@ -74,17 +77,26 @@ function createOptions() {
 }
 
 function createApp(postgraphileOptions: PostGraphileOptions) {
+  const pool = new Pool({
+    host: config.db.host,
+    database: config.db.database,
+    port: config.db.port,
+    user: config.db.admin.login,
+    password: config.db.admin.password,
+  });
+
   const app = express();
   app.use(graphqlUploadExpress());
   app.use(
     "/uploads",
     express.static("uploads", {
-      setHeaders: function (res, path, stat) {
+      setHeaders: function (res) {
         res.set("Content-Disposition", "attachment");
       },
     })
   );
-  app.use(postgraphile(getDbUrl("user"), "ctfnote", postgraphileOptions));
+  app.use(postgraphile(pool, "ctfnote", postgraphileOptions));
+  app.use("/calendar.ics", icalRoute(pool));
   return app;
 }
 

--- a/api/src/routes/ical.ts
+++ b/api/src/routes/ical.ts
@@ -1,0 +1,73 @@
+import { ICalCalendar } from "ical-generator";
+import { Request, Response, Handler } from "express";
+import { Pool } from "pg";
+import slugify from "slugify";
+
+type CtfRow = {
+  id: number;
+  title: string;
+  start_time: string;
+  end_time: string;
+  ctf_url: string;
+  description: string;
+};
+
+type IcalPasswordRow = {
+  ical_password: string;
+};
+
+export function icalRoute(pool: Pool): Handler {
+  async function checkIcalPassword(
+    userPass: string | undefined
+  ): Promise<boolean> {
+    const r = await pool.query<IcalPasswordRow>(
+      "SELECT ical_password FROM ctfnote.settings"
+    );
+    const db_password = r.rows[0].ical_password;
+    // If the password is null or empty allow any user
+    if (!db_password) return true;
+    return db_password === userPass;
+  }
+
+  async function getCtfs(): Promise<CtfRow[]> {
+    const r = await pool.query<CtfRow>(
+      "SELECT id, title, start_time, end_time, ctf_url, description FROM ctfnote.ctf"
+    );
+
+    return r.rows;
+  }
+
+  return async function (req: Request, res: Response): Promise<void> {
+    const { key } = req.query;
+
+    if (
+      !(typeof key == "string" || key == undefined) ||
+      !(await checkIcalPassword(key))
+    ) {
+      res.status(403);
+      res.send("Forbidden\n");
+      return;
+    }
+
+    const cal = new ICalCalendar({ name: "CTFNote" });
+    const ctfs = await getCtfs();
+
+    for (const ctf of ctfs) {
+      // I'm not sure if this works in all cases (e.g. if ctfs aren't at /#/ctf/<id> but at /ctfnote/#/ctf/<id>...)
+      const ctf_url = new URL(
+        `/#/ctf/${ctf.id}-${slugify(ctf.title)}/info`,
+        `${req.protocol}://${req.headers.host}`
+      );
+
+      cal.createEvent({
+        start: ctf.start_time,
+        end: ctf.end_time,
+        description: ctf.description,
+        summary: ctf.title,
+        url: ctf_url.href,
+      });
+    }
+
+    cal.serve(res);
+  };
+}

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -1472,6 +1472,13 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+ical-generator@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ical-generator/-/ical-generator-3.2.1.tgz#cf3101faa721c8a6e89302fa86162099c0444e99"
+  integrity sha512-mUvSpy5k6mgddz5PwlCcTiyIq34vL8i94LSq9f1T19/8CWO6jl9uvczE7qwjbn0SpVk8EdqqoF8ipO6pzecZNQ==
+  dependencies:
+    uuid-random "^1.3.2"
+
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -2931,6 +2938,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+uuid-random@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/uuid-random/-/uuid-random-1.3.2.tgz#96715edbaef4e84b1dcf5024b00d16f30220e2d0"
+  integrity sha512-UOzej0Le/UgkbWEO8flm+0y+G+ljUon1QWTEZOq1rnMAsxo2+SckbiZdKzAHHlVh6gJqI1TjC/xwgR50MuCrBQ==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -2609,6 +2609,11 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
+slugify@^1.6.5:
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.6.5.tgz#c8f5c072bf2135b80703589b39a3d41451fbe8c8"
+  integrity sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ==
+
 source-map-support@^0.5.17:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"

--- a/front/.gitignore
+++ b/front/.gitignore
@@ -32,3 +32,5 @@ yarn-error.log*
 *.njsproj
 *.sln
 .vscode
+graphql.schema.json
+

--- a/front/.lintstagedrc.json
+++ b/front/.lintstagedrc.json
@@ -1,3 +1,3 @@
 {
-    "*.{js,ts,vue,graphql}": "eslint"
+    "*.{js,ts,vue}": "eslint"
 }

--- a/front/graphql.schema.json
+++ b/front/graphql.schema.json
@@ -7074,6 +7074,12 @@
             "deprecationReason": null
           },
           {
+            "name": "USER_FRIEND",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "USER_GUEST",
             "description": null,
             "isDeprecated": false,
@@ -7099,6 +7105,18 @@
         "name": "Setting",
         "description": null,
         "fields": [
+          {
+            "name": "icalPassword",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "nodeId",
             "description": "A globally unique identifier. Can be used in various places throughout the system to identify this single value.",
@@ -7213,6 +7231,18 @@
         "description": "Represents an update to a `Setting`. Fields that are set will be updated.",
         "fields": null,
         "inputFields": [
+          {
+            "name": "icalPassword",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "registrationAllowed",
             "description": null,

--- a/front/nginx.conf
+++ b/front/nginx.conf
@@ -36,6 +36,17 @@ server {
         add_header Pragma "no-cache";
     }
 
+    location /calendar.ics {
+        proxy_pass   http://api:3000/calendar.ics;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $http_connection;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        add_header Pragma "no-cache";
+    }
+
     location /pad/ {
         proxy_pass   http://hedgedoc:3000/;
         proxy_http_version 1.1;

--- a/front/package.json
+++ b/front/package.json
@@ -9,7 +9,7 @@
     "build": "quasar build",
     "dev": "quasar dev",
     "format": "prettier --write '**/*.{js,vue,graphql}'",
-    "lint": "eslint --ext .js,.ts,.vue,.graphql ./",
+    "lint": "eslint --ext .js,.ts,.vue, ./",
     "test": "echo \"No test specified\" && exit 0",
     "codegen": "graphql-codegen --config codegen.yml"
   },

--- a/front/quasar.conf.js
+++ b/front/quasar.conf.js
@@ -87,6 +87,9 @@ module.exports = configure(function (ctx) {
         '/uploads': {
           target: 'http://127.0.0.1:3000',
         },
+        '/calendar.ics': {
+          target: 'http://127.0.0.1:3000',
+        },
         '/pad': {
           target: 'http://127.0.0.1:3001/',
           pathRewrite: {

--- a/front/src/components/Admin/Registration.vue
+++ b/front/src/components/Admin/Registration.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="row q-gutter-md">
     <div class="col">
-      <q-card bordered>
+      <q-card bordered class="q-mb-md">
         <q-card-section>
           <div class="text-h6">Registration</div>
         </q-card-section>
@@ -12,6 +12,30 @@
               left-label
               label="Allow registration on CTFNote"
             />
+          </div>
+        </q-card-section>
+      </q-card>
+      <q-card bordered>
+        <q-card-section>
+          <div class="text-h6">Calendar Password</div>
+        </q-card-section>
+        <q-card-section>
+          <div>
+            <q-input v-model="icalPassword">
+              <template #after>
+                <q-btn
+                  icon="save"
+                  round
+                  :color="
+                    icalPassword == adminSettings.icalPassword
+                      ? 'grey-5'
+                      : 'positive'
+                  "
+                  :disabled="icalPassword == adminSettings.icalPassword"
+                  @click="updateIcalPassword"
+                />
+              </template>
+            </q-input>
           </div>
         </q-card-section>
       </q-card>
@@ -73,11 +97,13 @@ export default defineComponent({
     const { result: adminSettings } = ctfnote.settings.getAdminSettings();
 
     const registrationPassword = ref('');
+    const icalPassword = ref('');
 
     watch(
       adminSettings,
       (s) => {
-        registrationPassword.value = s.registrationPassword ?? '';
+        registrationPassword.value = s.registrationPassword;
+        icalPassword.value = s.icalPassword;
       },
       { immediate: true }
     );
@@ -87,6 +113,7 @@ export default defineComponent({
       updateSettings: ctfnote.settings.useUpdateSettings(),
       adminSettings,
       registrationPassword,
+      icalPassword,
     };
   },
   computed: {
@@ -155,6 +182,19 @@ export default defineComponent({
       void this.resolveAndNotify(
         this.updateSettings({
           registrationPassword: this.registrationPassword,
+        }),
+        opts
+      );
+    },
+    updateIcalPassword() {
+      const opts = {
+        message: 'Calendar password changed!',
+        icon: 'today',
+      };
+
+      void this.resolveAndNotify(
+        this.updateSettings({
+          icalPassword: this.icalPassword,
         }),
         opts
       );

--- a/front/src/components/Admin/Users.vue
+++ b/front/src/components/Admin/Users.vue
@@ -110,7 +110,9 @@ const columns = [
   {
     name: 'lastactive',
     label: 'Last active',
-    field: (u: User) => { return date.formatDate(u.profile.lastactive, 'YYYY-MM-DD HH:mm:ss') },
+    field: (u: User) => {
+      return date.formatDate(u.profile.lastactive, 'YYYY-MM-DD HH:mm:ss');
+    },
     sortable: true,
   },
   {

--- a/front/src/components/Auth/Register.vue
+++ b/front/src/components/Auth/Register.vue
@@ -12,9 +12,12 @@
             label="Choose a login"
             lazy-rules
             :rules="[
-              val => (val && val.length > 0) || 'Please type something',
-              val => (val && val.indexOf('@') === -1) || 'Please don\'t use @',
-              val => (val && val !== 'ctfnote') || 'ctfnote is resvered for internal use.',
+              (val) => (val && val.length > 0) || 'Please type something',
+              (val) =>
+                (val && val.indexOf('@') === -1) || 'Please don\'t use @',
+              (val) =>
+                (val && val !== 'ctfnote') ||
+                'ctfnote is resvered for internal use.',
             ]"
             required
           />
@@ -25,7 +28,8 @@
             required
             lazy-rules
             :rules="[
-              val => (val && val.length > 5) || 'At least 6 characters please.',
+              (val) =>
+                (val && val.length > 5) || 'At least 6 characters please.',
             ]"
           />
           <q-input

--- a/front/src/components/CTF/Calendar.vue
+++ b/front/src/components/CTF/Calendar.vue
@@ -72,16 +72,7 @@
             <div
               v-for="(event, index) in getEvents(timestamp)"
               :key="index"
-              class="
-                text-white
-                col
-                row
-                justify-center
-                items-center
-                full-width
-                event
-                cursor-pointer
-              "
+              class="text-white col row justify-center items-center full-width event cursor-pointer"
               :style="event.style"
               @click="clickCtf(event.ctf)"
             >

--- a/front/src/components/CTF/Calendar.vue
+++ b/front/src/components/CTF/Calendar.vue
@@ -1,7 +1,7 @@
 <template>
   <q-card>
     <q-card-section>
-      <div v-if="$q.screen.gt.md" class="row justify-between items-center">
+      <div v-if="$q.screen.gt.sm" class="row justify-between items-center">
         <q-btn
           icon="arrow_back_ios"
           flat
@@ -11,6 +11,13 @@
         <div class="row items-center q-gutter-md">
           <q-btn round flat icon="today" title="Today" @click="showToday" />
           <div class="text-h5">{{ currentMonth }}</div>
+          <q-btn
+            round
+            flat
+            icon="link"
+            title="iCalendar"
+            @click="showIcalLink = true"
+          />
         </div>
         <q-btn
           icon-right="arrow_forward_ios"
@@ -23,6 +30,13 @@
         <div class="row col col-12 items-center justify-center q-gutter-md">
           <q-btn round flat icon="today" title="Today" @click="showToday" />
           <div class="text-h5">{{ currentMonth }}</div>
+          <q-btn
+            round
+            flat
+            icon="link"
+            title="iCalendar"
+            @click="showIcalLink = true"
+          />
         </div>
         <q-btn
           icon="arrow_back_ios"
@@ -58,7 +72,16 @@
             <div
               v-for="(event, index) in getEvents(timestamp)"
               :key="index"
-              class="text-white col row justify-center items-center full-width event cursor-pointer"
+              class="
+                text-white
+                col
+                row
+                justify-center
+                items-center
+                full-width
+                event
+                cursor-pointer
+              "
               :style="event.style"
               @click="clickCtf(event.ctf)"
             >
@@ -69,6 +92,29 @@
       </q-calendar-month>
     </q-card-section>
   </q-card>
+  <q-dialog v-model="showIcalLink" seamless position="top">
+    <q-card style="width: 450px">
+      <q-card-section class="row items-center q-gutter-sm q-px-sm">
+        <div class="col-auto">
+          <q-icon name="link" size="md" />
+        </div>
+        <div class="col">
+          <q-input
+            ref="icalEl"
+            label="iCalendar"
+            :model-value="icalLink"
+            readonly
+            outlined
+            class="bg-dark"
+          />
+        </div>
+
+        <div class="col-auto">
+          <q-btn v-close-popup flat round icon="close" />
+        </div>
+      </q-card-section>
+    </q-card>
+  </q-dialog>
 </template>
 
 <script lang="ts">
@@ -85,7 +131,8 @@ import '@quasar/quasar-ui-qcalendar/src/QCalendarTransitions.sass';
 import '@quasar/quasar-ui-qcalendar/src/QCalendarVariables.sass';
 import { Ctf } from 'src/ctfnote/models';
 import ctfnote from 'src/ctfnote';
-import { defineComponent, ref } from 'vue';
+import { defineComponent, ref, computed } from 'vue';
+import { QInput } from 'quasar';
 
 function dateToLocale(s: string, offset = 0): string {
   const [year, month] = s.split('-').map((e) => parseInt(e));
@@ -96,13 +143,27 @@ function dateToLocale(s: string, offset = 0): string {
 export default defineComponent({
   components: { QCalendarMonth },
   setup() {
+    const icalEl = ref<QInput>();
     const { result: ctfs, loading } = ctfnote.ctfs.getAllCtfs();
+    const { result: icalPassword } = ctfnote.settings.getIcalPassword();
+
+    const icalLink = computed(() => {
+      icalEl.value?.select();
+      return (
+        document.location.origin +
+        '/calendar.ics?key=' +
+        encodeURIComponent(icalPassword.value)
+      );
+    });
     return {
       calendar: ref<QCalendar>(),
       ctfs,
       loading,
       animated: ref(false),
       selectedDate: ref(today()),
+      showIcalLink: ref(false),
+      icalLink,
+      icalEl,
     };
   },
   computed: {

--- a/front/src/components/CTF/Guests.vue
+++ b/front/src/components/CTF/Guests.vue
@@ -58,7 +58,11 @@ export default defineComponent({
   },
   computed: {
     guests() {
-      return this.team.filter((p) => p.role == Role.UserGuest || (p.role == Role.UserFriend && this.ctf.endTime > this.now));
+      return this.team.filter(
+        (p) =>
+          p.role == Role.UserGuest ||
+          (p.role == Role.UserFriend && this.ctf.endTime > this.now)
+      );
     },
     guestsWithInvitation() {
       return this.guests.map((g) => {

--- a/front/src/components/Menu/BaseMenuBar.vue
+++ b/front/src/components/Menu/BaseMenuBar.vue
@@ -3,7 +3,12 @@
     <q-toolbar>
       <q-toolbar-title class="row items-center q-gutter-md">
         <ctf-note-link name="index" class="text-white" underline>
-          <q-img src="/favicon-transparent.svg" width="30px" class="q-mr-md" :ratio="1" />
+          <q-img
+            src="/favicon-transparent.svg"
+            width="30px"
+            class="q-mr-md"
+            :ratio="1"
+          />
           <q-btn flat no-caps>CTFNote</q-btn>
         </ctf-note-link>
         <slot name="after-title" />

--- a/front/src/ctfnote/models.ts
+++ b/front/src/ctfnote/models.ts
@@ -101,6 +101,7 @@ export type Settings = {
 export type AdminSettings = Settings & {
   registrationPassword: string;
   registrationDefaultRole: Role;
+  icalPassword: string;
 };
 
 export type User = {

--- a/front/src/ctfnote/settings.ts
+++ b/front/src/ctfnote/settings.ts
@@ -6,6 +6,7 @@ import {
   SettingPatch,
   SettingsInfoFragment,
   useGetAdminSettingsQuery,
+  useGetIcalPasswordQuery,
   useGetSettingsQuery,
   useUpdateSettingsMutation,
 } from 'src/generated/graphql';
@@ -50,6 +51,7 @@ export function buildAdminSettings(
     registrationPassword: fragment.registrationPassword ?? '',
     registrationDefaultRole: fragment.registrationDefaultRole ?? Role.UserGuest,
     style: parseStyle(fragment.style ?? '{}'),
+    icalPassword: fragment.icalPassword ?? '',
   };
 }
 
@@ -93,6 +95,13 @@ export function getAdminSettings() {
   return wrapQuery(r, buildAdminSettings({}), (data) => {
     settingsNodeId = data.settings.nodes[0].nodeId;
     return buildAdminSettings(data.settings.nodes[0]);
+  });
+}
+
+export function getIcalPassword() {
+  const r = useGetIcalPasswordQuery();
+  return wrapQuery(r, 'no pass', (data) => {
+    return data.settings.nodes[0].icalPassword;
   });
 }
 

--- a/front/src/generated/graphql.ts
+++ b/front/src/generated/graphql.ts
@@ -1396,14 +1396,15 @@ export type ResetPasswordPayload = {
 
 export enum Role {
   UserAdmin = 'USER_ADMIN',
+  UserFriend = 'USER_FRIEND',
   UserGuest = 'USER_GUEST',
   UserManager = 'USER_MANAGER',
-  UserMember = 'USER_MEMBER',
-  UserFriend = 'USER_FRIEND',
+  UserMember = 'USER_MEMBER'
 }
 
 export type Setting = Node & {
   __typename?: 'Setting';
+  icalPassword?: Maybe<Scalars['String']>;
   /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
   nodeId: Scalars['ID'];
   registrationAllowed: Scalars['Boolean'];
@@ -1415,6 +1416,7 @@ export type Setting = Node & {
 
 /** Represents an update to a `Setting`. Fields that are set will be updated. */
 export type SettingPatch = {
+  icalPassword?: InputMaybe<Scalars['String']>;
   registrationAllowed?: InputMaybe<Scalars['Boolean']>;
   registrationDefaultRole?: InputMaybe<Role>;
   registrationPassword?: InputMaybe<Scalars['String']>;
@@ -2260,17 +2262,22 @@ export type UpdateCredentialsForCtfIdMutation = { __typename?: 'Mutation', updat
 
 export type SettingsInfoFragment = { __typename?: 'Setting', nodeId: string, registrationAllowed: boolean, registrationPasswordAllowed: boolean, style: string };
 
-export type AdminSettingsInfoFragment = { __typename?: 'Setting', nodeId: string, registrationPassword: string, registrationDefaultRole: Role, registrationAllowed: boolean, registrationPasswordAllowed: boolean, style: string };
+export type AdminSettingsInfoFragment = { __typename?: 'Setting', nodeId: string, registrationPassword: string, registrationDefaultRole: Role, icalPassword?: string | null | undefined, registrationAllowed: boolean, registrationPasswordAllowed: boolean, style: string };
 
 export type GetSettingsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type GetSettingsQuery = { __typename?: 'Query', settings?: { __typename?: 'SettingsConnection', nodes: Array<{ __typename?: 'Setting', nodeId: string, registrationAllowed: boolean, registrationPasswordAllowed: boolean, style: string }> } | null | undefined };
 
+export type GetIcalPasswordQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetIcalPasswordQuery = { __typename?: 'Query', settings?: { __typename?: 'SettingsConnection', nodes: Array<{ __typename?: 'Setting', nodeId: string, icalPassword?: string | null | undefined }> } | null | undefined };
+
 export type GetAdminSettingsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetAdminSettingsQuery = { __typename?: 'Query', settings?: { __typename?: 'SettingsConnection', nodes: Array<{ __typename?: 'Setting', nodeId: string, registrationPassword: string, registrationDefaultRole: Role, registrationAllowed: boolean, registrationPasswordAllowed: boolean, style: string }> } | null | undefined };
+export type GetAdminSettingsQuery = { __typename?: 'Query', settings?: { __typename?: 'SettingsConnection', nodes: Array<{ __typename?: 'Setting', nodeId: string, registrationPassword: string, registrationDefaultRole: Role, icalPassword?: string | null | undefined, registrationAllowed: boolean, registrationPasswordAllowed: boolean, style: string }> } | null | undefined };
 
 export type UpdateSettingsMutationVariables = Exact<{
   nodeId: Scalars['ID'];
@@ -2278,7 +2285,7 @@ export type UpdateSettingsMutationVariables = Exact<{
 }>;
 
 
-export type UpdateSettingsMutation = { __typename?: 'Mutation', updateSettingByNodeId?: { __typename?: 'UpdateSettingPayload', setting?: { __typename?: 'Setting', nodeId: string, registrationPassword: string, registrationDefaultRole: Role, registrationAllowed: boolean, registrationPasswordAllowed: boolean, style: string } | null | undefined } | null | undefined };
+export type UpdateSettingsMutation = { __typename?: 'Mutation', updateSettingByNodeId?: { __typename?: 'UpdateSettingPayload', setting?: { __typename?: 'Setting', nodeId: string, registrationPassword: string, registrationDefaultRole: Role, icalPassword?: string | null | undefined, registrationAllowed: boolean, registrationPasswordAllowed: boolean, style: string } | null | undefined } | null | undefined };
 
 export type WorkingOnFragment = { __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined, nodeId: string } | null | undefined };
 
@@ -2465,6 +2472,7 @@ export const AdminSettingsInfoFragmentDoc = gql`
   ...SettingsInfo
   registrationPassword
   registrationDefaultRole
+  icalPassword
 }
     ${SettingsInfoFragmentDoc}`;
 export const GetUsersDocument = gql`
@@ -3539,6 +3547,33 @@ export function useGetSettingsQuery(options: VueApolloComposable.UseQueryOptions
   return VueApolloComposable.useQuery<GetSettingsQuery, GetSettingsQueryVariables>(GetSettingsDocument, {}, options);
 }
 export type GetSettingsQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<GetSettingsQuery, GetSettingsQueryVariables>;
+export const GetIcalPasswordDocument = gql`
+    query getIcalPassword {
+  settings {
+    nodes {
+      nodeId
+      icalPassword
+    }
+  }
+}
+    `;
+
+/**
+ * __useGetIcalPasswordQuery__
+ *
+ * To run a query within a Vue component, call `useGetIcalPasswordQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetIcalPasswordQuery` returns an object from Apollo Client that contains result, loading and error properties
+ * you can use to render your UI.
+ *
+ * @param options that will be passed into the query, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/query.html#options;
+ *
+ * @example
+ * const { result, loading, error } = useGetIcalPasswordQuery();
+ */
+export function useGetIcalPasswordQuery(options: VueApolloComposable.UseQueryOptions<GetIcalPasswordQuery, GetIcalPasswordQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<GetIcalPasswordQuery, GetIcalPasswordQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<GetIcalPasswordQuery, GetIcalPasswordQueryVariables>> = {}) {
+  return VueApolloComposable.useQuery<GetIcalPasswordQuery, GetIcalPasswordQueryVariables>(GetIcalPasswordDocument, {}, options);
+}
+export type GetIcalPasswordQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<GetIcalPasswordQuery, GetIcalPasswordQueryVariables>;
 export const GetAdminSettingsDocument = gql`
     query getAdminSettings {
   settings {
@@ -4008,6 +4043,7 @@ export const AdminSettingsInfo = gql`
   ...SettingsInfo
   registrationPassword
   registrationDefaultRole
+  icalPassword
 }
     ${SettingsInfo}`;
 export const GetUsers = gql`
@@ -4341,6 +4377,16 @@ export const GetSettings = gql`
   }
 }
     ${SettingsInfo}`;
+export const GetIcalPassword = gql`
+    query getIcalPassword {
+  settings {
+    nodes {
+      nodeId
+      icalPassword
+    }
+  }
+}
+    `;
 export const GetAdminSettings = gql`
     query getAdminSettings {
   settings {

--- a/front/src/generated/graphql.ts
+++ b/front/src/generated/graphql.ts
@@ -2002,33 +2002,33 @@ export enum WorkOnTasksOrderBy {
   TaskIdDesc = 'TASK_ID_DESC'
 }
 
-export type UserFragment = { __typename?: 'User', nodeId?: string | null | undefined, login?: string | null | undefined, role?: Role | null | undefined, id?: number | null | undefined, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined, nodeId: string } | null | undefined };
+export type UserFragment = { __typename?: 'User', nodeId?: string | null, login?: string | null, role?: Role | null, id?: number | null, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null, description: string, lastactive: string, role?: Role | null, nodeId: string } | null };
 
 export type GetUsersQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetUsersQuery = { __typename?: 'Query', users?: { __typename?: 'UsersConnection', nodes: Array<{ __typename?: 'User', nodeId?: string | null | undefined, login?: string | null | undefined, role?: Role | null | undefined, id?: number | null | undefined, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined, nodeId: string } | null | undefined }> } | null | undefined };
+export type GetUsersQuery = { __typename?: 'Query', users?: { __typename?: 'UsersConnection', nodes: Array<{ __typename?: 'User', nodeId?: string | null, login?: string | null, role?: Role | null, id?: number | null, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null, description: string, lastactive: string, role?: Role | null, nodeId: string } | null }> } | null };
 
 export type CreateInvitationTokenMutationVariables = Exact<{
   role: Role;
 }>;
 
 
-export type CreateInvitationTokenMutation = { __typename?: 'Mutation', createInvitationLink?: { __typename?: 'CreateInvitationLinkPayload', invitationLinkResponse?: { __typename?: 'InvitationLinkResponse', token?: string | null | undefined } | null | undefined } | null | undefined };
+export type CreateInvitationTokenMutation = { __typename?: 'Mutation', createInvitationLink?: { __typename?: 'CreateInvitationLinkPayload', invitationLinkResponse?: { __typename?: 'InvitationLinkResponse', token?: string | null } | null } | null };
 
 export type CreateResetPasswordTokenMutationVariables = Exact<{
   userId: Scalars['Int'];
 }>;
 
 
-export type CreateResetPasswordTokenMutation = { __typename?: 'Mutation', createResetPasswordLink?: { __typename?: 'CreateResetPasswordLinkPayload', resetPasswordLinkResponse?: { __typename?: 'ResetPasswordLinkResponse', token?: string | null | undefined } | null | undefined } | null | undefined };
+export type CreateResetPasswordTokenMutation = { __typename?: 'Mutation', createResetPasswordLink?: { __typename?: 'CreateResetPasswordLinkPayload', resetPasswordLinkResponse?: { __typename?: 'ResetPasswordLinkResponse', token?: string | null } | null } | null };
 
 export type DeleteUserByIdMutationVariables = Exact<{
   userId: Scalars['Int'];
 }>;
 
 
-export type DeleteUserByIdMutation = { __typename?: 'Mutation', deleteUser?: { __typename?: 'DeleteUserPayload', userResponse?: { __typename?: 'UserResponse', id?: number | null | undefined, login?: string | null | undefined, role?: Role | null | undefined } | null | undefined } | null | undefined };
+export type DeleteUserByIdMutation = { __typename?: 'Mutation', deleteUser?: { __typename?: 'DeleteUserPayload', userResponse?: { __typename?: 'UserResponse', id?: number | null, login?: string | null, role?: Role | null } | null } | null };
 
 export type UpdateRoleForUserIdMutationVariables = Exact<{
   userId: Scalars['Int'];
@@ -2036,17 +2036,17 @@ export type UpdateRoleForUserIdMutationVariables = Exact<{
 }>;
 
 
-export type UpdateRoleForUserIdMutation = { __typename?: 'Mutation', updateUserRole?: { __typename?: 'UpdateUserRolePayload', role?: Role | null | undefined } | null | undefined };
+export type UpdateRoleForUserIdMutation = { __typename?: 'Mutation', updateUserRole?: { __typename?: 'UpdateUserRolePayload', role?: Role | null } | null };
 
 export type MeQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type MeQuery = { __typename?: 'Query', me?: { __typename?: 'Profile', id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined, nodeId: string } | null | undefined };
+export type MeQuery = { __typename?: 'Query', me?: { __typename?: 'Profile', id: number, username: string, color?: string | null, description: string, lastactive: string, role?: Role | null, nodeId: string } | null };
 
 export type NewTokenQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type NewTokenQuery = { __typename?: 'Query', newToken?: string | null | undefined };
+export type NewTokenQuery = { __typename?: 'Query', newToken?: string | null };
 
 export type LoginMutationVariables = Exact<{
   login: Scalars['String'];
@@ -2054,7 +2054,7 @@ export type LoginMutationVariables = Exact<{
 }>;
 
 
-export type LoginMutation = { __typename?: 'Mutation', login?: { __typename?: 'LoginPayload', jwt?: string | null | undefined } | null | undefined };
+export type LoginMutation = { __typename?: 'Mutation', login?: { __typename?: 'LoginPayload', jwt?: string | null } | null };
 
 export type RegisterMutationVariables = Exact<{
   login: Scalars['String'];
@@ -2062,7 +2062,7 @@ export type RegisterMutationVariables = Exact<{
 }>;
 
 
-export type RegisterMutation = { __typename?: 'Mutation', register?: { __typename?: 'RegisterPayload', jwt?: string | null | undefined } | null | undefined };
+export type RegisterMutation = { __typename?: 'Mutation', register?: { __typename?: 'RegisterPayload', jwt?: string | null } | null };
 
 export type RegisterWithTokenMutationVariables = Exact<{
   login: Scalars['String'];
@@ -2071,7 +2071,7 @@ export type RegisterWithTokenMutationVariables = Exact<{
 }>;
 
 
-export type RegisterWithTokenMutation = { __typename?: 'Mutation', registerWithToken?: { __typename?: 'RegisterWithTokenPayload', jwt?: string | null | undefined } | null | undefined };
+export type RegisterWithTokenMutation = { __typename?: 'Mutation', registerWithToken?: { __typename?: 'RegisterWithTokenPayload', jwt?: string | null } | null };
 
 export type RegisterWithPasswordMutationVariables = Exact<{
   login: Scalars['String'];
@@ -2080,7 +2080,7 @@ export type RegisterWithPasswordMutationVariables = Exact<{
 }>;
 
 
-export type RegisterWithPasswordMutation = { __typename?: 'Mutation', registerWithPassword?: { __typename?: 'RegisterWithPasswordPayload', jwt?: string | null | undefined } | null | undefined };
+export type RegisterWithPasswordMutation = { __typename?: 'Mutation', registerWithPassword?: { __typename?: 'RegisterWithPasswordPayload', jwt?: string | null } | null };
 
 export type ResetPasswordMutationVariables = Exact<{
   password: Scalars['String'];
@@ -2088,99 +2088,99 @@ export type ResetPasswordMutationVariables = Exact<{
 }>;
 
 
-export type ResetPasswordMutation = { __typename?: 'Mutation', resetPassword?: { __typename?: 'ResetPasswordPayload', jwt?: string | null | undefined } | null | undefined };
+export type ResetPasswordMutation = { __typename?: 'Mutation', resetPassword?: { __typename?: 'ResetPasswordPayload', jwt?: string | null } | null };
 
-export type CtfFragment = { __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null | undefined, ctfUrl?: string | null | undefined, ctftimeUrl?: string | null | undefined, description: string, endTime: string, logoUrl?: string | null | undefined, startTime: string, weight: number, title: string };
+export type CtfFragment = { __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null, ctfUrl?: string | null, ctftimeUrl?: string | null, description: string, endTime: string, logoUrl?: string | null, startTime: string, weight: number, title: string };
 
-export type FullCtfFragment = { __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null | undefined, ctfUrl?: string | null | undefined, ctftimeUrl?: string | null | undefined, description: string, endTime: string, logoUrl?: string | null | undefined, startTime: string, weight: number, title: string, tasks: { __typename?: 'TasksConnection', nodes: Array<{ __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null | undefined, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined, nodeId: string } | null | undefined }> } }> }, secrets?: { __typename?: 'CtfSecret', nodeId: string, credentials?: string | null | undefined } | null | undefined, invitations: { __typename?: 'InvitationsConnection', nodes: Array<{ __typename?: 'Invitation', nodeId: string, ctfId: number, profileId: number }> } };
+export type FullCtfFragment = { __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null, ctfUrl?: string | null, ctftimeUrl?: string | null, description: string, endTime: string, logoUrl?: string | null, startTime: string, weight: number, title: string, tasks: { __typename?: 'TasksConnection', nodes: Array<{ __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null, description: string, lastactive: string, role?: Role | null, nodeId: string } | null }> } }> }, secrets?: { __typename?: 'CtfSecret', nodeId: string, credentials?: string | null } | null, invitations: { __typename?: 'InvitationsConnection', nodes: Array<{ __typename?: 'Invitation', nodeId: string, ctfId: number, profileId: number }> } };
 
 export type CtfsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type CtfsQuery = { __typename?: 'Query', ctfs?: { __typename?: 'CtfsConnection', nodes: Array<{ __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null | undefined, ctfUrl?: string | null | undefined, ctftimeUrl?: string | null | undefined, description: string, endTime: string, logoUrl?: string | null | undefined, startTime: string, weight: number, title: string }> } | null | undefined };
+export type CtfsQuery = { __typename?: 'Query', ctfs?: { __typename?: 'CtfsConnection', nodes: Array<{ __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null, ctfUrl?: string | null, ctftimeUrl?: string | null, description: string, endTime: string, logoUrl?: string | null, startTime: string, weight: number, title: string }> } | null };
 
 export type SubscribeToCtfSubscriptionVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SubscribeToCtfSubscription = { __typename?: 'Subscription', listen: { __typename?: 'ListenPayload', relatedNodeId?: string | null | undefined, relatedNode?: { __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null | undefined, ctfUrl?: string | null | undefined, ctftimeUrl?: string | null | undefined, description: string, endTime: string, logoUrl?: string | null | undefined, startTime: string, weight: number, title: string, tasks: { __typename?: 'TasksConnection', nodes: Array<{ __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null | undefined, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined, nodeId: string } | null | undefined }> } }> }, secrets?: { __typename?: 'CtfSecret', nodeId: string, credentials?: string | null | undefined } | null | undefined, invitations: { __typename?: 'InvitationsConnection', nodes: Array<{ __typename?: 'Invitation', nodeId: string, ctfId: number, profileId: number }> } } | { __typename?: 'CtfSecret', nodeId: string } | { __typename?: 'Invitation', nodeId: string } | { __typename?: 'Profile', nodeId: string } | { __typename?: 'Query', nodeId: string } | { __typename?: 'Setting', nodeId: string } | { __typename?: 'Task', nodeId: string } | { __typename?: 'WorkOnTask', nodeId: string } | null | undefined } };
+export type SubscribeToCtfSubscription = { __typename?: 'Subscription', listen: { __typename?: 'ListenPayload', relatedNodeId?: string | null, relatedNode?: { __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null, ctfUrl?: string | null, ctftimeUrl?: string | null, description: string, endTime: string, logoUrl?: string | null, startTime: string, weight: number, title: string, tasks: { __typename?: 'TasksConnection', nodes: Array<{ __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null, description: string, lastactive: string, role?: Role | null, nodeId: string } | null }> } }> }, secrets?: { __typename?: 'CtfSecret', nodeId: string, credentials?: string | null } | null, invitations: { __typename?: 'InvitationsConnection', nodes: Array<{ __typename?: 'Invitation', nodeId: string, ctfId: number, profileId: number }> } } | { __typename?: 'CtfSecret', nodeId: string } | { __typename?: 'Invitation', nodeId: string } | { __typename?: 'Profile', nodeId: string } | { __typename?: 'Query', nodeId: string } | { __typename?: 'Setting', nodeId: string } | { __typename?: 'Task', nodeId: string } | { __typename?: 'WorkOnTask', nodeId: string } | null } };
 
 export type GetFullCtfQueryVariables = Exact<{
   id: Scalars['Int'];
 }>;
 
 
-export type GetFullCtfQuery = { __typename?: 'Query', ctf?: { __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null | undefined, ctfUrl?: string | null | undefined, ctftimeUrl?: string | null | undefined, description: string, endTime: string, logoUrl?: string | null | undefined, startTime: string, weight: number, title: string, tasks: { __typename?: 'TasksConnection', nodes: Array<{ __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null | undefined, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined, nodeId: string } | null | undefined }> } }> }, secrets?: { __typename?: 'CtfSecret', nodeId: string, credentials?: string | null | undefined } | null | undefined, invitations: { __typename?: 'InvitationsConnection', nodes: Array<{ __typename?: 'Invitation', nodeId: string, ctfId: number, profileId: number }> } } | null | undefined };
+export type GetFullCtfQuery = { __typename?: 'Query', ctf?: { __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null, ctfUrl?: string | null, ctftimeUrl?: string | null, description: string, endTime: string, logoUrl?: string | null, startTime: string, weight: number, title: string, tasks: { __typename?: 'TasksConnection', nodes: Array<{ __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null, description: string, lastactive: string, role?: Role | null, nodeId: string } | null }> } }> }, secrets?: { __typename?: 'CtfSecret', nodeId: string, credentials?: string | null } | null, invitations: { __typename?: 'InvitationsConnection', nodes: Array<{ __typename?: 'Invitation', nodeId: string, ctfId: number, profileId: number }> } } | null };
 
 export type IncomingCtfsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type IncomingCtfsQuery = { __typename?: 'Query', incomingCtf?: { __typename?: 'CtfsConnection', nodes: Array<{ __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null | undefined, ctfUrl?: string | null | undefined, ctftimeUrl?: string | null | undefined, description: string, endTime: string, logoUrl?: string | null | undefined, startTime: string, weight: number, title: string }> } | null | undefined };
+export type IncomingCtfsQuery = { __typename?: 'Query', incomingCtf?: { __typename?: 'CtfsConnection', nodes: Array<{ __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null, ctfUrl?: string | null, ctftimeUrl?: string | null, description: string, endTime: string, logoUrl?: string | null, startTime: string, weight: number, title: string }> } | null };
 
 export type PastCtfsQueryVariables = Exact<{
-  first?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
 }>;
 
 
-export type PastCtfsQuery = { __typename?: 'Query', pastCtf?: { __typename?: 'CtfsConnection', totalCount: number, nodes: Array<{ __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null | undefined, ctfUrl?: string | null | undefined, ctftimeUrl?: string | null | undefined, description: string, endTime: string, logoUrl?: string | null | undefined, startTime: string, weight: number, title: string }> } | null | undefined };
+export type PastCtfsQuery = { __typename?: 'Query', pastCtf?: { __typename?: 'CtfsConnection', totalCount: number, nodes: Array<{ __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null, ctfUrl?: string | null, ctftimeUrl?: string | null, description: string, endTime: string, logoUrl?: string | null, startTime: string, weight: number, title: string }> } | null };
 
 export type CreateCtfMutationVariables = Exact<{
   title: Scalars['String'];
   startTime: Scalars['Datetime'];
   endTime: Scalars['Datetime'];
-  weight?: Maybe<Scalars['Float']>;
-  ctfUrl?: Maybe<Scalars['String']>;
-  ctftimeUrl?: Maybe<Scalars['String']>;
-  logoUrl?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
+  weight?: InputMaybe<Scalars['Float']>;
+  ctfUrl?: InputMaybe<Scalars['String']>;
+  ctftimeUrl?: InputMaybe<Scalars['String']>;
+  logoUrl?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']>;
 }>;
 
 
-export type CreateCtfMutation = { __typename?: 'Mutation', createCtf?: { __typename?: 'CreateCtfPayload', ctf?: { __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null | undefined, ctfUrl?: string | null | undefined, ctftimeUrl?: string | null | undefined, description: string, endTime: string, logoUrl?: string | null | undefined, startTime: string, weight: number, title: string } | null | undefined } | null | undefined };
+export type CreateCtfMutation = { __typename?: 'Mutation', createCtf?: { __typename?: 'CreateCtfPayload', ctf?: { __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null, ctfUrl?: string | null, ctftimeUrl?: string | null, description: string, endTime: string, logoUrl?: string | null, startTime: string, weight: number, title: string } | null } | null };
 
 export type DeleteCtfbyIdMutationVariables = Exact<{
   id: Scalars['Int'];
 }>;
 
 
-export type DeleteCtfbyIdMutation = { __typename?: 'Mutation', deleteCtf?: { __typename?: 'DeleteCtfPayload', deletedCtfNodeId?: string | null | undefined } | null | undefined };
+export type DeleteCtfbyIdMutation = { __typename?: 'Mutation', deleteCtf?: { __typename?: 'DeleteCtfPayload', deletedCtfNodeId?: string | null } | null };
 
 export type ImportctfMutationVariables = Exact<{
   id: Scalars['Int'];
 }>;
 
 
-export type ImportctfMutation = { __typename?: 'Mutation', importCtf?: { __typename?: 'ImportCtfPayload', ctf?: { __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null | undefined, ctfUrl?: string | null | undefined, ctftimeUrl?: string | null | undefined, description: string, endTime: string, logoUrl?: string | null | undefined, startTime: string, weight: number, title: string } | null | undefined } | null | undefined };
+export type ImportctfMutation = { __typename?: 'Mutation', importCtf?: { __typename?: 'ImportCtfPayload', ctf?: { __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null, ctfUrl?: string | null, ctftimeUrl?: string | null, description: string, endTime: string, logoUrl?: string | null, startTime: string, weight: number, title: string } | null } | null };
 
 export type UpdateCtfByIdMutationVariables = Exact<{
   id: Scalars['Int'];
-  title?: Maybe<Scalars['String']>;
-  weight?: Maybe<Scalars['Float']>;
-  ctfUrl?: Maybe<Scalars['String']>;
-  ctftimeUrl?: Maybe<Scalars['String']>;
-  logoUrl?: Maybe<Scalars['String']>;
-  startTime?: Maybe<Scalars['Datetime']>;
-  endTime?: Maybe<Scalars['Datetime']>;
-  description?: Maybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+  weight?: InputMaybe<Scalars['Float']>;
+  ctfUrl?: InputMaybe<Scalars['String']>;
+  ctftimeUrl?: InputMaybe<Scalars['String']>;
+  logoUrl?: InputMaybe<Scalars['String']>;
+  startTime?: InputMaybe<Scalars['Datetime']>;
+  endTime?: InputMaybe<Scalars['Datetime']>;
+  description?: InputMaybe<Scalars['String']>;
 }>;
 
 
-export type UpdateCtfByIdMutation = { __typename?: 'Mutation', updateCtf?: { __typename?: 'UpdateCtfPayload', ctf?: { __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null | undefined, ctfUrl?: string | null | undefined, ctftimeUrl?: string | null | undefined, description: string, endTime: string, logoUrl?: string | null | undefined, startTime: string, weight: number, title: string } | null | undefined } | null | undefined };
+export type UpdateCtfByIdMutation = { __typename?: 'Mutation', updateCtf?: { __typename?: 'UpdateCtfPayload', ctf?: { __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null, ctfUrl?: string | null, ctftimeUrl?: string | null, description: string, endTime: string, logoUrl?: string | null, startTime: string, weight: number, title: string } | null } | null };
 
 export type SubscribeToCtfCreatedSubscriptionVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SubscribeToCtfCreatedSubscription = { __typename?: 'Subscription', listen: { __typename?: 'ListenPayload', relatedNodeId?: string | null | undefined, relatedNode?: { __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null | undefined, ctfUrl?: string | null | undefined, ctftimeUrl?: string | null | undefined, description: string, endTime: string, logoUrl?: string | null | undefined, startTime: string, weight: number, title: string } | { __typename?: 'CtfSecret' } | { __typename?: 'Invitation' } | { __typename?: 'Profile' } | { __typename?: 'Query' } | { __typename?: 'Setting' } | { __typename?: 'Task' } | { __typename?: 'WorkOnTask' } | null | undefined } };
+export type SubscribeToCtfCreatedSubscription = { __typename?: 'Subscription', listen: { __typename?: 'ListenPayload', relatedNodeId?: string | null, relatedNode?: { __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null, ctfUrl?: string | null, ctftimeUrl?: string | null, description: string, endTime: string, logoUrl?: string | null, startTime: string, weight: number, title: string } | { __typename?: 'CtfSecret' } | { __typename?: 'Invitation' } | { __typename?: 'Profile' } | { __typename?: 'Query' } | { __typename?: 'Setting' } | { __typename?: 'Task' } | { __typename?: 'WorkOnTask' } | null } };
 
 export type SubscribeToCtfDeletedSubscriptionVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SubscribeToCtfDeletedSubscription = { __typename?: 'Subscription', listen: { __typename?: 'ListenPayload', relatedNodeId?: string | null | undefined, relatedNode?: { __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null | undefined, ctfUrl?: string | null | undefined, ctftimeUrl?: string | null | undefined, description: string, endTime: string, logoUrl?: string | null | undefined, startTime: string, weight: number, title: string } | { __typename?: 'CtfSecret' } | { __typename?: 'Invitation' } | { __typename?: 'Profile' } | { __typename?: 'Query' } | { __typename?: 'Setting' } | { __typename?: 'Task' } | { __typename?: 'WorkOnTask' } | null | undefined } };
+export type SubscribeToCtfDeletedSubscription = { __typename?: 'Subscription', listen: { __typename?: 'ListenPayload', relatedNodeId?: string | null, relatedNode?: { __typename?: 'Ctf', nodeId: string, id: number, granted?: boolean | null, ctfUrl?: string | null, ctftimeUrl?: string | null, description: string, endTime: string, logoUrl?: string | null, startTime: string, weight: number, title: string } | { __typename?: 'CtfSecret' } | { __typename?: 'Invitation' } | { __typename?: 'Profile' } | { __typename?: 'Query' } | { __typename?: 'Setting' } | { __typename?: 'Task' } | { __typename?: 'WorkOnTask' } | null } };
 
 export type SubscribeToFlagSubscriptionVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SubscribeToFlagSubscription = { __typename?: 'Subscription', listen: { __typename?: 'ListenPayload', relatedNodeId?: string | null | undefined, relatedNode?: { __typename?: 'Ctf' } | { __typename?: 'CtfSecret' } | { __typename?: 'Invitation' } | { __typename?: 'Profile' } | { __typename?: 'Query' } | { __typename?: 'Setting' } | { __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null | undefined, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined, nodeId: string } | null | undefined }> } } | { __typename?: 'WorkOnTask' } | null | undefined } };
+export type SubscribeToFlagSubscription = { __typename?: 'Subscription', listen: { __typename?: 'ListenPayload', relatedNodeId?: string | null, relatedNode?: { __typename?: 'Ctf' } | { __typename?: 'CtfSecret' } | { __typename?: 'Invitation' } | { __typename?: 'Profile' } | { __typename?: 'Query' } | { __typename?: 'Setting' } | { __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null, description: string, lastactive: string, role?: Role | null, nodeId: string } | null }> } } | { __typename?: 'WorkOnTask' } | null } };
 
 export type InvitationFragment = { __typename?: 'Invitation', nodeId: string, ctfId: number, profileId: number };
 
@@ -2190,7 +2190,7 @@ export type InviteUserToCtfMutationVariables = Exact<{
 }>;
 
 
-export type InviteUserToCtfMutation = { __typename?: 'Mutation', createInvitation?: { __typename?: 'CreateInvitationPayload', invitation?: { __typename?: 'Invitation', nodeId: string, ctfId: number, profileId: number } | null | undefined } | null | undefined };
+export type InviteUserToCtfMutation = { __typename?: 'Mutation', createInvitation?: { __typename?: 'CreateInvitationPayload', invitation?: { __typename?: 'Invitation', nodeId: string, ctfId: number, profileId: number } | null } | null };
 
 export type UninviteUserToCtfMutationVariables = Exact<{
   ctfId: Scalars['Int'];
@@ -2198,9 +2198,9 @@ export type UninviteUserToCtfMutationVariables = Exact<{
 }>;
 
 
-export type UninviteUserToCtfMutation = { __typename?: 'Mutation', deleteInvitation?: { __typename?: 'DeleteInvitationPayload', deletedInvitationNodeId?: string | null | undefined } | null | undefined };
+export type UninviteUserToCtfMutation = { __typename?: 'Mutation', deleteInvitation?: { __typename?: 'DeleteInvitationPayload', deletedInvitationNodeId?: string | null } | null };
 
-export type ProfileFragment = { __typename?: 'Profile', id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined, nodeId: string };
+export type ProfileFragment = { __typename?: 'Profile', id: number, username: string, color?: string | null, description: string, lastactive: string, role?: Role | null, nodeId: string };
 
 export type UpdatePasswordMutationVariables = Exact<{
   oldPassword: Scalars['String'];
@@ -2208,7 +2208,7 @@ export type UpdatePasswordMutationVariables = Exact<{
 }>;
 
 
-export type UpdatePasswordMutation = { __typename?: 'Mutation', changePassword?: { __typename?: 'ChangePasswordPayload', changePasswordResponse?: { __typename?: 'ChangePasswordResponse', ok?: boolean | null | undefined } | null | undefined } | null | undefined };
+export type UpdatePasswordMutation = { __typename?: 'Mutation', changePassword?: { __typename?: 'ChangePasswordPayload', changePasswordResponse?: { __typename?: 'ChangePasswordResponse', ok?: boolean | null } | null } | null };
 
 export type UpdateProfileMutationVariables = Exact<{
   id: Scalars['Int'];
@@ -2216,68 +2216,68 @@ export type UpdateProfileMutationVariables = Exact<{
 }>;
 
 
-export type UpdateProfileMutation = { __typename?: 'Mutation', updateProfile?: { __typename?: 'UpdateProfilePayload', profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined, nodeId: string } | null | undefined } | null | undefined };
+export type UpdateProfileMutation = { __typename?: 'Mutation', updateProfile?: { __typename?: 'UpdateProfilePayload', profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null, description: string, lastactive: string, role?: Role | null, nodeId: string } | null } | null };
 
 export type UpdateLastActiveMutationVariables = Exact<{ [key: string]: never; }>;
 
 
-export type UpdateLastActiveMutation = { __typename?: 'Mutation', updateLastActive?: { __typename?: 'UpdateLastActivePayload', updateLastActiveResponse?: { __typename?: 'UpdateLastActiveResponse', ok?: boolean | null | undefined } | null | undefined } | null | undefined };
+export type UpdateLastActiveMutation = { __typename?: 'Mutation', updateLastActive?: { __typename?: 'UpdateLastActivePayload', updateLastActiveResponse?: { __typename?: 'UpdateLastActiveResponse', ok?: boolean | null } | null } | null };
 
 export type GetTeamQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetTeamQuery = { __typename?: 'Query', profiles?: { __typename?: 'ProfilesConnection', nodes: Array<{ __typename?: 'Profile', id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined, nodeId: string }> } | null | undefined };
+export type GetTeamQuery = { __typename?: 'Query', profiles?: { __typename?: 'ProfilesConnection', nodes: Array<{ __typename?: 'Profile', id: number, username: string, color?: string | null, description: string, lastactive: string, role?: Role | null, nodeId: string }> } | null };
 
 export type SubscribeToProfileSubscriptionVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SubscribeToProfileSubscription = { __typename?: 'Subscription', listen: { __typename?: 'ListenPayload', relatedNode?: { __typename?: 'Ctf', nodeId: string } | { __typename?: 'CtfSecret', nodeId: string } | { __typename?: 'Invitation', nodeId: string } | { __typename?: 'Profile', nodeId: string, id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined } | { __typename?: 'Query', nodeId: string } | { __typename?: 'Setting', nodeId: string } | { __typename?: 'Task', nodeId: string } | { __typename?: 'WorkOnTask', nodeId: string } | null | undefined } };
+export type SubscribeToProfileSubscription = { __typename?: 'Subscription', listen: { __typename?: 'ListenPayload', relatedNode?: { __typename?: 'Ctf', nodeId: string } | { __typename?: 'CtfSecret', nodeId: string } | { __typename?: 'Invitation', nodeId: string } | { __typename?: 'Profile', nodeId: string, id: number, username: string, color?: string | null, description: string, lastactive: string, role?: Role | null } | { __typename?: 'Query', nodeId: string } | { __typename?: 'Setting', nodeId: string } | { __typename?: 'Task', nodeId: string } | { __typename?: 'WorkOnTask', nodeId: string } | null } };
 
 export type SubscribeToProfileCreatedSubscriptionVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SubscribeToProfileCreatedSubscription = { __typename?: 'Subscription', listen: { __typename?: 'ListenPayload', relatedNodeId?: string | null | undefined, relatedNode?: { __typename?: 'Ctf', nodeId: string } | { __typename?: 'CtfSecret', nodeId: string } | { __typename?: 'Invitation', nodeId: string } | { __typename?: 'Profile', nodeId: string, id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined } | { __typename?: 'Query', nodeId: string } | { __typename?: 'Setting', nodeId: string } | { __typename?: 'Task', nodeId: string } | { __typename?: 'WorkOnTask', nodeId: string } | null | undefined } };
+export type SubscribeToProfileCreatedSubscription = { __typename?: 'Subscription', listen: { __typename?: 'ListenPayload', relatedNodeId?: string | null, relatedNode?: { __typename?: 'Ctf', nodeId: string } | { __typename?: 'CtfSecret', nodeId: string } | { __typename?: 'Invitation', nodeId: string } | { __typename?: 'Profile', nodeId: string, id: number, username: string, color?: string | null, description: string, lastactive: string, role?: Role | null } | { __typename?: 'Query', nodeId: string } | { __typename?: 'Setting', nodeId: string } | { __typename?: 'Task', nodeId: string } | { __typename?: 'WorkOnTask', nodeId: string } | null } };
 
 export type SubscribeToProfileDeletedSubscriptionVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SubscribeToProfileDeletedSubscription = { __typename?: 'Subscription', listen: { __typename?: 'ListenPayload', relatedNodeId?: string | null | undefined, relatedNode?: { __typename?: 'Ctf', nodeId: string } | { __typename?: 'CtfSecret', nodeId: string } | { __typename?: 'Invitation', nodeId: string } | { __typename?: 'Profile', nodeId: string, id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined } | { __typename?: 'Query', nodeId: string } | { __typename?: 'Setting', nodeId: string } | { __typename?: 'Task', nodeId: string } | { __typename?: 'WorkOnTask', nodeId: string } | null | undefined } };
+export type SubscribeToProfileDeletedSubscription = { __typename?: 'Subscription', listen: { __typename?: 'ListenPayload', relatedNodeId?: string | null, relatedNode?: { __typename?: 'Ctf', nodeId: string } | { __typename?: 'CtfSecret', nodeId: string } | { __typename?: 'Invitation', nodeId: string } | { __typename?: 'Profile', nodeId: string, id: number, username: string, color?: string | null, description: string, lastactive: string, role?: Role | null } | { __typename?: 'Query', nodeId: string } | { __typename?: 'Setting', nodeId: string } | { __typename?: 'Task', nodeId: string } | { __typename?: 'WorkOnTask', nodeId: string } | null } };
 
-export type CtfSecretFragment = { __typename?: 'CtfSecret', nodeId: string, credentials?: string | null | undefined };
+export type CtfSecretFragment = { __typename?: 'CtfSecret', nodeId: string, credentials?: string | null };
 
 export type GetCredentialsForCtfIdQueryVariables = Exact<{
   ctfId: Scalars['Int'];
 }>;
 
 
-export type GetCredentialsForCtfIdQuery = { __typename?: 'Query', ctfSecret?: { __typename?: 'CtfSecret', nodeId: string, credentials?: string | null | undefined } | null | undefined };
+export type GetCredentialsForCtfIdQuery = { __typename?: 'Query', ctfSecret?: { __typename?: 'CtfSecret', nodeId: string, credentials?: string | null } | null };
 
 export type UpdateCredentialsForCtfIdMutationVariables = Exact<{
   ctfId: Scalars['Int'];
-  credentials?: Maybe<Scalars['String']>;
+  credentials?: InputMaybe<Scalars['String']>;
 }>;
 
 
-export type UpdateCredentialsForCtfIdMutation = { __typename?: 'Mutation', updateCtfSecret?: { __typename?: 'UpdateCtfSecretPayload', ctfSecret?: { __typename?: 'CtfSecret', nodeId: string, credentials?: string | null | undefined } | null | undefined } | null | undefined };
+export type UpdateCredentialsForCtfIdMutation = { __typename?: 'Mutation', updateCtfSecret?: { __typename?: 'UpdateCtfSecretPayload', ctfSecret?: { __typename?: 'CtfSecret', nodeId: string, credentials?: string | null } | null } | null };
 
 export type SettingsInfoFragment = { __typename?: 'Setting', nodeId: string, registrationAllowed: boolean, registrationPasswordAllowed: boolean, style: string };
 
-export type AdminSettingsInfoFragment = { __typename?: 'Setting', nodeId: string, registrationPassword: string, registrationDefaultRole: Role, icalPassword?: string | null | undefined, registrationAllowed: boolean, registrationPasswordAllowed: boolean, style: string };
+export type AdminSettingsInfoFragment = { __typename?: 'Setting', nodeId: string, registrationPassword: string, registrationDefaultRole: Role, icalPassword?: string | null, registrationAllowed: boolean, registrationPasswordAllowed: boolean, style: string };
 
 export type GetSettingsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetSettingsQuery = { __typename?: 'Query', settings?: { __typename?: 'SettingsConnection', nodes: Array<{ __typename?: 'Setting', nodeId: string, registrationAllowed: boolean, registrationPasswordAllowed: boolean, style: string }> } | null | undefined };
+export type GetSettingsQuery = { __typename?: 'Query', settings?: { __typename?: 'SettingsConnection', nodes: Array<{ __typename?: 'Setting', nodeId: string, registrationAllowed: boolean, registrationPasswordAllowed: boolean, style: string }> } | null };
 
 export type GetIcalPasswordQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetIcalPasswordQuery = { __typename?: 'Query', settings?: { __typename?: 'SettingsConnection', nodes: Array<{ __typename?: 'Setting', nodeId: string, icalPassword?: string | null | undefined }> } | null | undefined };
+export type GetIcalPasswordQuery = { __typename?: 'Query', settings?: { __typename?: 'SettingsConnection', nodes: Array<{ __typename?: 'Setting', nodeId: string, icalPassword?: string | null }> } | null };
 
 export type GetAdminSettingsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetAdminSettingsQuery = { __typename?: 'Query', settings?: { __typename?: 'SettingsConnection', nodes: Array<{ __typename?: 'Setting', nodeId: string, registrationPassword: string, registrationDefaultRole: Role, icalPassword?: string | null | undefined, registrationAllowed: boolean, registrationPasswordAllowed: boolean, style: string }> } | null | undefined };
+export type GetAdminSettingsQuery = { __typename?: 'Query', settings?: { __typename?: 'SettingsConnection', nodes: Array<{ __typename?: 'Setting', nodeId: string, registrationPassword: string, registrationDefaultRole: Role, icalPassword?: string | null, registrationAllowed: boolean, registrationPasswordAllowed: boolean, style: string }> } | null };
 
 export type UpdateSettingsMutationVariables = Exact<{
   nodeId: Scalars['ID'];
@@ -2285,73 +2285,73 @@ export type UpdateSettingsMutationVariables = Exact<{
 }>;
 
 
-export type UpdateSettingsMutation = { __typename?: 'Mutation', updateSettingByNodeId?: { __typename?: 'UpdateSettingPayload', setting?: { __typename?: 'Setting', nodeId: string, registrationPassword: string, registrationDefaultRole: Role, icalPassword?: string | null | undefined, registrationAllowed: boolean, registrationPasswordAllowed: boolean, style: string } | null | undefined } | null | undefined };
+export type UpdateSettingsMutation = { __typename?: 'Mutation', updateSettingByNodeId?: { __typename?: 'UpdateSettingPayload', setting?: { __typename?: 'Setting', nodeId: string, registrationPassword: string, registrationDefaultRole: Role, icalPassword?: string | null, registrationAllowed: boolean, registrationPasswordAllowed: boolean, style: string } | null } | null };
 
-export type WorkingOnFragment = { __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined, nodeId: string } | null | undefined };
+export type WorkingOnFragment = { __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null, description: string, lastactive: string, role?: Role | null, nodeId: string } | null };
 
-export type TaskFragment = { __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null | undefined, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined, nodeId: string } | null | undefined }> } };
+export type TaskFragment = { __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null, description: string, lastactive: string, role?: Role | null, nodeId: string } | null }> } };
 
 export type GetTasksForCtfIdQueryVariables = Exact<{
   ctfId: Scalars['Int'];
 }>;
 
 
-export type GetTasksForCtfIdQuery = { __typename?: 'Query', tasks?: { __typename?: 'TasksConnection', nodes: Array<{ __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null | undefined, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined, nodeId: string } | null | undefined }> } }> } | null | undefined };
+export type GetTasksForCtfIdQuery = { __typename?: 'Query', tasks?: { __typename?: 'TasksConnection', nodes: Array<{ __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null, description: string, lastactive: string, role?: Role | null, nodeId: string } | null }> } }> } | null };
 
 export type TaskByIdQueryVariables = Exact<{
   id: Scalars['Int'];
 }>;
 
 
-export type TaskByIdQuery = { __typename?: 'Query', task?: { __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null | undefined, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined, nodeId: string } | null | undefined }> } } | null | undefined };
+export type TaskByIdQuery = { __typename?: 'Query', task?: { __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null, description: string, lastactive: string, role?: Role | null, nodeId: string } | null }> } } | null };
 
 export type UpdateTaskMutationVariables = Exact<{
   id: Scalars['Int'];
-  title?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  category?: Maybe<Scalars['String']>;
-  flag?: Maybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']>;
+  category?: InputMaybe<Scalars['String']>;
+  flag?: InputMaybe<Scalars['String']>;
 }>;
 
 
-export type UpdateTaskMutation = { __typename?: 'Mutation', updateTask?: { __typename?: 'UpdateTaskPayload', task?: { __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null | undefined, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined, nodeId: string } | null | undefined }> } } | null | undefined } | null | undefined };
+export type UpdateTaskMutation = { __typename?: 'Mutation', updateTask?: { __typename?: 'UpdateTaskPayload', task?: { __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null, description: string, lastactive: string, role?: Role | null, nodeId: string } | null }> } } | null } | null };
 
 export type CreateTaskForCtfIdMutationVariables = Exact<{
   ctfId: Scalars['Int'];
   title: Scalars['String'];
-  category?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  flag?: Maybe<Scalars['String']>;
+  category?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']>;
+  flag?: InputMaybe<Scalars['String']>;
 }>;
 
 
-export type CreateTaskForCtfIdMutation = { __typename?: 'Mutation', createTask?: { __typename?: 'CreateTaskPayload', task?: { __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null | undefined, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined, nodeId: string } | null | undefined }> } } | null | undefined } | null | undefined };
+export type CreateTaskForCtfIdMutation = { __typename?: 'Mutation', createTask?: { __typename?: 'CreateTaskPayload', task?: { __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null, description: string, lastactive: string, role?: Role | null, nodeId: string } | null }> } } | null } | null };
 
 export type DeleteTaskMutationVariables = Exact<{
   id: Scalars['Int'];
 }>;
 
 
-export type DeleteTaskMutation = { __typename?: 'Mutation', deleteTask?: { __typename?: 'DeleteTaskPayload', deletedTaskNodeId?: string | null | undefined } | null | undefined };
+export type DeleteTaskMutation = { __typename?: 'Mutation', deleteTask?: { __typename?: 'DeleteTaskPayload', deletedTaskNodeId?: string | null } | null };
 
 export type StartWorkingOnMutationVariables = Exact<{
   taskId: Scalars['Int'];
 }>;
 
 
-export type StartWorkingOnMutation = { __typename?: 'Mutation', startWorkingOn?: { __typename?: 'StartWorkingOnPayload', task?: { __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null | undefined, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined, nodeId: string } | null | undefined }> } } | null | undefined } | null | undefined };
+export type StartWorkingOnMutation = { __typename?: 'Mutation', startWorkingOn?: { __typename?: 'StartWorkingOnPayload', task?: { __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null, description: string, lastactive: string, role?: Role | null, nodeId: string } | null }> } } | null } | null };
 
 export type StopWorkingOnMutationVariables = Exact<{
   taskId: Scalars['Int'];
 }>;
 
 
-export type StopWorkingOnMutation = { __typename?: 'Mutation', stopWorkingOn?: { __typename?: 'StopWorkingOnPayload', task?: { __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null | undefined, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined, nodeId: string } | null | undefined }> } } | null | undefined } | null | undefined };
+export type StopWorkingOnMutation = { __typename?: 'Mutation', stopWorkingOn?: { __typename?: 'StopWorkingOnPayload', task?: { __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null, description: string, lastactive: string, role?: Role | null, nodeId: string } | null }> } } | null } | null };
 
 export type SubscribeToTaskSubscriptionVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SubscribeToTaskSubscription = { __typename?: 'Subscription', listen: { __typename?: 'ListenPayload', relatedNode?: { __typename?: 'Ctf', nodeId: string } | { __typename?: 'CtfSecret', nodeId: string } | { __typename?: 'Invitation', nodeId: string } | { __typename?: 'Profile', nodeId: string } | { __typename?: 'Query', nodeId: string } | { __typename?: 'Setting', nodeId: string } | { __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null | undefined, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null | undefined, description: string, lastactive: string, role?: Role | null | undefined, nodeId: string } | null | undefined }> } } | { __typename?: 'WorkOnTask', nodeId: string } | null | undefined } };
+export type SubscribeToTaskSubscription = { __typename?: 'Subscription', listen: { __typename?: 'ListenPayload', relatedNode?: { __typename?: 'Ctf', nodeId: string } | { __typename?: 'CtfSecret', nodeId: string } | { __typename?: 'Invitation', nodeId: string } | { __typename?: 'Profile', nodeId: string } | { __typename?: 'Query', nodeId: string } | { __typename?: 'Setting', nodeId: string } | { __typename?: 'Task', nodeId: string, id: number, title: string, ctfId: number, padUrl: string, description: string, flag: string, solved?: boolean | null, category: string, workOnTasks: { __typename?: 'WorkOnTasksConnection', nodes: Array<{ __typename?: 'WorkOnTask', nodeId: string, profileId: number, profile?: { __typename?: 'Profile', id: number, username: string, color?: string | null, description: string, lastactive: string, role?: Role | null, nodeId: string } | null }> } } | { __typename?: 'WorkOnTask', nodeId: string } | null } };
 
 export type UploadLogoMutationVariables = Exact<{
   logo: Scalars['Upload'];
@@ -2499,6 +2499,9 @@ export const GetUsersDocument = gql`
  */
 export function useGetUsersQuery(options: VueApolloComposable.UseQueryOptions<GetUsersQuery, GetUsersQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<GetUsersQuery, GetUsersQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<GetUsersQuery, GetUsersQueryVariables>> = {}) {
   return VueApolloComposable.useQuery<GetUsersQuery, GetUsersQueryVariables>(GetUsersDocument, {}, options);
+}
+export function useGetUsersLazyQuery(options: VueApolloComposable.UseQueryOptions<GetUsersQuery, GetUsersQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<GetUsersQuery, GetUsersQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<GetUsersQuery, GetUsersQueryVariables>> = {}) {
+  return VueApolloComposable.useLazyQuery<GetUsersQuery, GetUsersQueryVariables>(GetUsersDocument, {}, options);
 }
 export type GetUsersQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<GetUsersQuery, GetUsersQueryVariables>;
 export const CreateInvitationTokenDocument = gql`
@@ -2649,6 +2652,9 @@ export const MeDocument = gql`
 export function useMeQuery(options: VueApolloComposable.UseQueryOptions<MeQuery, MeQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<MeQuery, MeQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<MeQuery, MeQueryVariables>> = {}) {
   return VueApolloComposable.useQuery<MeQuery, MeQueryVariables>(MeDocument, {}, options);
 }
+export function useMeLazyQuery(options: VueApolloComposable.UseQueryOptions<MeQuery, MeQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<MeQuery, MeQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<MeQuery, MeQueryVariables>> = {}) {
+  return VueApolloComposable.useLazyQuery<MeQuery, MeQueryVariables>(MeDocument, {}, options);
+}
 export type MeQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<MeQuery, MeQueryVariables>;
 export const NewTokenDocument = gql`
     query newToken {
@@ -2670,6 +2676,9 @@ export const NewTokenDocument = gql`
  */
 export function useNewTokenQuery(options: VueApolloComposable.UseQueryOptions<NewTokenQuery, NewTokenQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<NewTokenQuery, NewTokenQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<NewTokenQuery, NewTokenQueryVariables>> = {}) {
   return VueApolloComposable.useQuery<NewTokenQuery, NewTokenQueryVariables>(NewTokenDocument, {}, options);
+}
+export function useNewTokenLazyQuery(options: VueApolloComposable.UseQueryOptions<NewTokenQuery, NewTokenQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<NewTokenQuery, NewTokenQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<NewTokenQuery, NewTokenQueryVariables>> = {}) {
+  return VueApolloComposable.useLazyQuery<NewTokenQuery, NewTokenQueryVariables>(NewTokenDocument, {}, options);
 }
 export type NewTokenQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<NewTokenQuery, NewTokenQueryVariables>;
 export const LoginDocument = gql`
@@ -2851,6 +2860,9 @@ export const CtfsDocument = gql`
 export function useCtfsQuery(options: VueApolloComposable.UseQueryOptions<CtfsQuery, CtfsQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<CtfsQuery, CtfsQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<CtfsQuery, CtfsQueryVariables>> = {}) {
   return VueApolloComposable.useQuery<CtfsQuery, CtfsQueryVariables>(CtfsDocument, {}, options);
 }
+export function useCtfsLazyQuery(options: VueApolloComposable.UseQueryOptions<CtfsQuery, CtfsQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<CtfsQuery, CtfsQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<CtfsQuery, CtfsQueryVariables>> = {}) {
+  return VueApolloComposable.useLazyQuery<CtfsQuery, CtfsQueryVariables>(CtfsDocument, {}, options);
+}
 export type CtfsQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<CtfsQuery, CtfsQueryVariables>;
 export const SubscribeToCtfDocument = gql`
     subscription subscribeToCtf {
@@ -2908,6 +2920,9 @@ export const GetFullCtfDocument = gql`
 export function useGetFullCtfQuery(variables: GetFullCtfQueryVariables | VueCompositionApi.Ref<GetFullCtfQueryVariables> | ReactiveFunction<GetFullCtfQueryVariables>, options: VueApolloComposable.UseQueryOptions<GetFullCtfQuery, GetFullCtfQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<GetFullCtfQuery, GetFullCtfQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<GetFullCtfQuery, GetFullCtfQueryVariables>> = {}) {
   return VueApolloComposable.useQuery<GetFullCtfQuery, GetFullCtfQueryVariables>(GetFullCtfDocument, variables, options);
 }
+export function useGetFullCtfLazyQuery(variables: GetFullCtfQueryVariables | VueCompositionApi.Ref<GetFullCtfQueryVariables> | ReactiveFunction<GetFullCtfQueryVariables>, options: VueApolloComposable.UseQueryOptions<GetFullCtfQuery, GetFullCtfQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<GetFullCtfQuery, GetFullCtfQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<GetFullCtfQuery, GetFullCtfQueryVariables>> = {}) {
+  return VueApolloComposable.useLazyQuery<GetFullCtfQuery, GetFullCtfQueryVariables>(GetFullCtfDocument, variables, options);
+}
 export type GetFullCtfQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<GetFullCtfQuery, GetFullCtfQueryVariables>;
 export const IncomingCtfsDocument = gql`
     query IncomingCtfs {
@@ -2933,6 +2948,9 @@ export const IncomingCtfsDocument = gql`
  */
 export function useIncomingCtfsQuery(options: VueApolloComposable.UseQueryOptions<IncomingCtfsQuery, IncomingCtfsQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<IncomingCtfsQuery, IncomingCtfsQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<IncomingCtfsQuery, IncomingCtfsQueryVariables>> = {}) {
   return VueApolloComposable.useQuery<IncomingCtfsQuery, IncomingCtfsQueryVariables>(IncomingCtfsDocument, {}, options);
+}
+export function useIncomingCtfsLazyQuery(options: VueApolloComposable.UseQueryOptions<IncomingCtfsQuery, IncomingCtfsQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<IncomingCtfsQuery, IncomingCtfsQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<IncomingCtfsQuery, IncomingCtfsQueryVariables>> = {}) {
+  return VueApolloComposable.useLazyQuery<IncomingCtfsQuery, IncomingCtfsQueryVariables>(IncomingCtfsDocument, {}, options);
 }
 export type IncomingCtfsQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<IncomingCtfsQuery, IncomingCtfsQueryVariables>;
 export const PastCtfsDocument = gql`
@@ -2964,6 +2982,9 @@ export const PastCtfsDocument = gql`
  */
 export function usePastCtfsQuery(variables: PastCtfsQueryVariables | VueCompositionApi.Ref<PastCtfsQueryVariables> | ReactiveFunction<PastCtfsQueryVariables> = {}, options: VueApolloComposable.UseQueryOptions<PastCtfsQuery, PastCtfsQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<PastCtfsQuery, PastCtfsQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<PastCtfsQuery, PastCtfsQueryVariables>> = {}) {
   return VueApolloComposable.useQuery<PastCtfsQuery, PastCtfsQueryVariables>(PastCtfsDocument, variables, options);
+}
+export function usePastCtfsLazyQuery(variables: PastCtfsQueryVariables | VueCompositionApi.Ref<PastCtfsQueryVariables> | ReactiveFunction<PastCtfsQueryVariables> = {}, options: VueApolloComposable.UseQueryOptions<PastCtfsQuery, PastCtfsQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<PastCtfsQuery, PastCtfsQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<PastCtfsQuery, PastCtfsQueryVariables>> = {}) {
+  return VueApolloComposable.useLazyQuery<PastCtfsQuery, PastCtfsQueryVariables>(PastCtfsDocument, variables, options);
 }
 export type PastCtfsQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<PastCtfsQuery, PastCtfsQueryVariables>;
 export const CreateCtfDocument = gql`
@@ -3372,6 +3393,9 @@ export const GetTeamDocument = gql`
 export function useGetTeamQuery(options: VueApolloComposable.UseQueryOptions<GetTeamQuery, GetTeamQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<GetTeamQuery, GetTeamQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<GetTeamQuery, GetTeamQueryVariables>> = {}) {
   return VueApolloComposable.useQuery<GetTeamQuery, GetTeamQueryVariables>(GetTeamDocument, {}, options);
 }
+export function useGetTeamLazyQuery(options: VueApolloComposable.UseQueryOptions<GetTeamQuery, GetTeamQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<GetTeamQuery, GetTeamQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<GetTeamQuery, GetTeamQueryVariables>> = {}) {
+  return VueApolloComposable.useLazyQuery<GetTeamQuery, GetTeamQueryVariables>(GetTeamDocument, {}, options);
+}
 export type GetTeamQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<GetTeamQuery, GetTeamQueryVariables>;
 export const SubscribeToProfileDocument = gql`
     subscription subscribeToProfile {
@@ -3488,6 +3512,9 @@ export const GetCredentialsForCtfIdDocument = gql`
 export function useGetCredentialsForCtfIdQuery(variables: GetCredentialsForCtfIdQueryVariables | VueCompositionApi.Ref<GetCredentialsForCtfIdQueryVariables> | ReactiveFunction<GetCredentialsForCtfIdQueryVariables>, options: VueApolloComposable.UseQueryOptions<GetCredentialsForCtfIdQuery, GetCredentialsForCtfIdQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<GetCredentialsForCtfIdQuery, GetCredentialsForCtfIdQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<GetCredentialsForCtfIdQuery, GetCredentialsForCtfIdQueryVariables>> = {}) {
   return VueApolloComposable.useQuery<GetCredentialsForCtfIdQuery, GetCredentialsForCtfIdQueryVariables>(GetCredentialsForCtfIdDocument, variables, options);
 }
+export function useGetCredentialsForCtfIdLazyQuery(variables: GetCredentialsForCtfIdQueryVariables | VueCompositionApi.Ref<GetCredentialsForCtfIdQueryVariables> | ReactiveFunction<GetCredentialsForCtfIdQueryVariables>, options: VueApolloComposable.UseQueryOptions<GetCredentialsForCtfIdQuery, GetCredentialsForCtfIdQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<GetCredentialsForCtfIdQuery, GetCredentialsForCtfIdQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<GetCredentialsForCtfIdQuery, GetCredentialsForCtfIdQueryVariables>> = {}) {
+  return VueApolloComposable.useLazyQuery<GetCredentialsForCtfIdQuery, GetCredentialsForCtfIdQueryVariables>(GetCredentialsForCtfIdDocument, variables, options);
+}
 export type GetCredentialsForCtfIdQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<GetCredentialsForCtfIdQuery, GetCredentialsForCtfIdQueryVariables>;
 export const UpdateCredentialsForCtfIdDocument = gql`
     mutation updateCredentialsForCtfId($ctfId: Int!, $credentials: String) {
@@ -3546,6 +3573,9 @@ export const GetSettingsDocument = gql`
 export function useGetSettingsQuery(options: VueApolloComposable.UseQueryOptions<GetSettingsQuery, GetSettingsQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<GetSettingsQuery, GetSettingsQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<GetSettingsQuery, GetSettingsQueryVariables>> = {}) {
   return VueApolloComposable.useQuery<GetSettingsQuery, GetSettingsQueryVariables>(GetSettingsDocument, {}, options);
 }
+export function useGetSettingsLazyQuery(options: VueApolloComposable.UseQueryOptions<GetSettingsQuery, GetSettingsQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<GetSettingsQuery, GetSettingsQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<GetSettingsQuery, GetSettingsQueryVariables>> = {}) {
+  return VueApolloComposable.useLazyQuery<GetSettingsQuery, GetSettingsQueryVariables>(GetSettingsDocument, {}, options);
+}
 export type GetSettingsQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<GetSettingsQuery, GetSettingsQueryVariables>;
 export const GetIcalPasswordDocument = gql`
     query getIcalPassword {
@@ -3573,6 +3603,9 @@ export const GetIcalPasswordDocument = gql`
 export function useGetIcalPasswordQuery(options: VueApolloComposable.UseQueryOptions<GetIcalPasswordQuery, GetIcalPasswordQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<GetIcalPasswordQuery, GetIcalPasswordQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<GetIcalPasswordQuery, GetIcalPasswordQueryVariables>> = {}) {
   return VueApolloComposable.useQuery<GetIcalPasswordQuery, GetIcalPasswordQueryVariables>(GetIcalPasswordDocument, {}, options);
 }
+export function useGetIcalPasswordLazyQuery(options: VueApolloComposable.UseQueryOptions<GetIcalPasswordQuery, GetIcalPasswordQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<GetIcalPasswordQuery, GetIcalPasswordQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<GetIcalPasswordQuery, GetIcalPasswordQueryVariables>> = {}) {
+  return VueApolloComposable.useLazyQuery<GetIcalPasswordQuery, GetIcalPasswordQueryVariables>(GetIcalPasswordDocument, {}, options);
+}
 export type GetIcalPasswordQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<GetIcalPasswordQuery, GetIcalPasswordQueryVariables>;
 export const GetAdminSettingsDocument = gql`
     query getAdminSettings {
@@ -3598,6 +3631,9 @@ export const GetAdminSettingsDocument = gql`
  */
 export function useGetAdminSettingsQuery(options: VueApolloComposable.UseQueryOptions<GetAdminSettingsQuery, GetAdminSettingsQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<GetAdminSettingsQuery, GetAdminSettingsQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<GetAdminSettingsQuery, GetAdminSettingsQueryVariables>> = {}) {
   return VueApolloComposable.useQuery<GetAdminSettingsQuery, GetAdminSettingsQueryVariables>(GetAdminSettingsDocument, {}, options);
+}
+export function useGetAdminSettingsLazyQuery(options: VueApolloComposable.UseQueryOptions<GetAdminSettingsQuery, GetAdminSettingsQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<GetAdminSettingsQuery, GetAdminSettingsQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<GetAdminSettingsQuery, GetAdminSettingsQueryVariables>> = {}) {
+  return VueApolloComposable.useLazyQuery<GetAdminSettingsQuery, GetAdminSettingsQueryVariables>(GetAdminSettingsDocument, {}, options);
 }
 export type GetAdminSettingsQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<GetAdminSettingsQuery, GetAdminSettingsQueryVariables>;
 export const UpdateSettingsDocument = gql`
@@ -3660,6 +3696,9 @@ export const GetTasksForCtfIdDocument = gql`
 export function useGetTasksForCtfIdQuery(variables: GetTasksForCtfIdQueryVariables | VueCompositionApi.Ref<GetTasksForCtfIdQueryVariables> | ReactiveFunction<GetTasksForCtfIdQueryVariables>, options: VueApolloComposable.UseQueryOptions<GetTasksForCtfIdQuery, GetTasksForCtfIdQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<GetTasksForCtfIdQuery, GetTasksForCtfIdQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<GetTasksForCtfIdQuery, GetTasksForCtfIdQueryVariables>> = {}) {
   return VueApolloComposable.useQuery<GetTasksForCtfIdQuery, GetTasksForCtfIdQueryVariables>(GetTasksForCtfIdDocument, variables, options);
 }
+export function useGetTasksForCtfIdLazyQuery(variables: GetTasksForCtfIdQueryVariables | VueCompositionApi.Ref<GetTasksForCtfIdQueryVariables> | ReactiveFunction<GetTasksForCtfIdQueryVariables>, options: VueApolloComposable.UseQueryOptions<GetTasksForCtfIdQuery, GetTasksForCtfIdQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<GetTasksForCtfIdQuery, GetTasksForCtfIdQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<GetTasksForCtfIdQuery, GetTasksForCtfIdQueryVariables>> = {}) {
+  return VueApolloComposable.useLazyQuery<GetTasksForCtfIdQuery, GetTasksForCtfIdQueryVariables>(GetTasksForCtfIdDocument, variables, options);
+}
 export type GetTasksForCtfIdQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<GetTasksForCtfIdQuery, GetTasksForCtfIdQueryVariables>;
 export const TaskByIdDocument = gql`
     query taskById($id: Int!) {
@@ -3686,6 +3725,9 @@ export const TaskByIdDocument = gql`
  */
 export function useTaskByIdQuery(variables: TaskByIdQueryVariables | VueCompositionApi.Ref<TaskByIdQueryVariables> | ReactiveFunction<TaskByIdQueryVariables>, options: VueApolloComposable.UseQueryOptions<TaskByIdQuery, TaskByIdQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<TaskByIdQuery, TaskByIdQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<TaskByIdQuery, TaskByIdQueryVariables>> = {}) {
   return VueApolloComposable.useQuery<TaskByIdQuery, TaskByIdQueryVariables>(TaskByIdDocument, variables, options);
+}
+export function useTaskByIdLazyQuery(variables: TaskByIdQueryVariables | VueCompositionApi.Ref<TaskByIdQueryVariables> | ReactiveFunction<TaskByIdQueryVariables>, options: VueApolloComposable.UseQueryOptions<TaskByIdQuery, TaskByIdQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<TaskByIdQuery, TaskByIdQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<TaskByIdQuery, TaskByIdQueryVariables>> = {}) {
+  return VueApolloComposable.useLazyQuery<TaskByIdQuery, TaskByIdQueryVariables>(TaskByIdDocument, variables, options);
 }
 export type TaskByIdQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<TaskByIdQuery, TaskByIdQueryVariables>;
 export const UpdateTaskDocument = gql`

--- a/front/src/graphql/Profile.graphql
+++ b/front/src/graphql/Profile.graphql
@@ -25,7 +25,7 @@ mutation updateProfile($id: Int!, $patch: ProfilePatch!) {
   }
 }
 mutation updateLastActive {
-  updateLastActive (input: { }) {
+  updateLastActive(input: {}) {
     updateLastActiveResponse {
       ok
     }

--- a/front/src/graphql/Settings.graphql
+++ b/front/src/graphql/Settings.graphql
@@ -10,6 +10,7 @@ fragment AdminSettingsInfo on Setting {
   ...SettingsInfo
   registrationPassword
   registrationDefaultRole
+  icalPassword
 }
 
 query getSettings {
@@ -19,6 +20,16 @@ query getSettings {
     }
   }
 }
+
+query getIcalPassword {
+  settings {
+    nodes {
+      nodeId
+      icalPassword
+    }
+  }
+}
+
 query getAdminSettings {
   settings {
     nodes {

--- a/front/src/pages/Admin.vue
+++ b/front/src/pages/Admin.vue
@@ -9,7 +9,7 @@
     >
       <q-route-tab
         :to="{ name: 'admin-registration' }"
-        label="Registration"
+        label="Authentication"
         icon="lock"
       />
       <q-route-tab :to="{ name: 'admin-theme' }" label="theme" icon="palette" />

--- a/front/src/pages/Settings.vue
+++ b/front/src/pages/Settings.vue
@@ -31,9 +31,14 @@
                     hint="Displayed name"
                     lazy-rules
                     :rules="[
-                      val => (val && val.length > 0) || 'Please type something',
-                      val => (val && val.indexOf('@') === -1) || 'Please don\'t use @',
-                      val => (val && val !== 'ctfnote') || 'ctfnote is resvered for internal use.',
+                      (val) =>
+                        (val && val.length > 0) || 'Please type something',
+                      (val) =>
+                        (val && val.indexOf('@') === -1) ||
+                        'Please don\'t use @',
+                      (val) =>
+                        (val && val !== 'ctfnote') ||
+                        'ctfnote is resvered for internal use.',
                     ]"
                     @keyup.enter="changeProfile"
                   >
@@ -70,8 +75,15 @@
           <q-card bordered>
             <q-form @submit="changePassword">
               <q-card-section>
-                <div class="text-h6"><span style="text-decoration: line-through;">Change Password</span></div>
-                <div>Disabled until further notice. Please contact an administrator if you need to change your password.</div>
+                <div class="text-h6">
+                  <span style="text-decoration: line-through"
+                    >Change Password</span
+                  >
+                </div>
+                <div>
+                  Disabled until further notice. Please contact an administrator
+                  if you need to change your password.
+                </div>
               </q-card-section>
               <q-separator class="q-mx-xl" />
               <q-card-section class="q-gutter-sm">


### PR DESCRIPTION
Sorry about the huge commit :/

* Adds a /calendar.ics?key=[....] endpoint where all CTFs are available in iCal Format
* The frontend calendar now shows a link to the iCal
* The key used for the calendar can be changed in the Admin Dashboard
Above changes by @B-i-t-K

To make this work, I had to do some minor fixes and make /calendar.ics available through the nginx proxy in front (and quasar config for development).

I also removed graphql files from eslint because we dropped the graphql eslint plugin.

This will close #30 and close #9 