### PR TITLE
ical combining (extension of #31)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,8 @@ temp/
 # .pnp.*
 
 # End of https://www.toptal.com/developers/gitignore/api/yarn,node
+
+### OWN ###
+
+#the real production config for the calendar
+/ical-relay/config/config.toml

--- a/.gitignore
+++ b/.gitignore
@@ -149,4 +149,4 @@ temp/
 ### OWN ###
 
 #the real production config for the calendar
-/ical-relay/config/config.toml
+config.toml

--- a/api/migrations/41-ical-link.sql
+++ b/api/migrations/41-ical-link.sql
@@ -1,5 +1,5 @@
 ALTER TABLE ctfnote.settings
-  ADD COLUMN "ical_password" TEXT DEFAULT encode(gen_random_bytes(16), 'hex');
+  ADD COLUMN "ical_password" TEXT DEFAULT "";
 
 GRANT SELECT ("ical_password") ON ctfnote.settings TO user_guest;
 

--- a/api/migrations/41-ical-link.sql
+++ b/api/migrations/41-ical-link.sql
@@ -1,5 +1,5 @@
 ALTER TABLE ctfnote.settings
-  ADD COLUMN "ical_password" TEXT DEFAULT "";
+  ADD COLUMN "ical_password" TEXT DEFAULT '';
 
 GRANT SELECT ("ical_password") ON ctfnote.settings TO user_guest;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,17 @@ services:
       - pad-uploads:/hedgedoc/public/uploads
     networks:
       - ctfnote
+  ical-relay:
+    build: ./ical-relay
+    restart: unless-stopped
+    volumes:
+      - ./ical-relay/config:/config
+    depends_on:
+      - front
+    networks:
+      - ctfnote
+    ports:
+      - 48080:8080
 volumes:
   ctfnote-db:
     name: ctfnote

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,8 +70,6 @@ services:
       - front
     networks:
       - ctfnote
-    ports:
-      - 48080:8080
 volumes:
   ctfnote-db:
     name: ctfnote

--- a/front/nginx.conf
+++ b/front/nginx.conf
@@ -37,7 +37,7 @@ server {
     }
 
     location /calendar.ics {
-        proxy_pass   http://api:3000/calendar.ics;
+        proxy_pass   http://ical-relay:8080/profiles/du4lcombined;
         proxy_http_version 1.1;
         proxy_set_header Host $http_host;
         proxy_set_header Upgrade $http_upgrade;

--- a/ical-relay/Dockerfile
+++ b/ical-relay/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang
+
+RUN apt-get update && apt-get install golang-rice git -y
+
+WORKDIR /app
+RUN git clone --branch staging https://github.com/JM-Lemmi/ical-relay ical-relay
+RUN git clone --branch staging https://github.com/JM-Lemmi/golang-ical golang-ical
+
+WORKDIR /app/ical-relay
+RUN rice embed-go && go build .
+
+WORKDIR /config
+
+CMD /app/ical-relay/ical-relay

--- a/ical-relay/Dockerfile
+++ b/ical-relay/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install golang-rice git -y
 
 WORKDIR /app
 RUN git clone --branch staging https://github.com/JM-Lemmi/ical-relay ical-relay
-RUN git clone --branch staging https://github.com/JM-Lemmi/golang-ical golang-ical
+RUN git clone --branch issue52 https://github.com/arran4/golang-ical golang-ical
 
 WORKDIR /app/ical-relay
 RUN rice embed-go && go build .

--- a/ical-relay/config/config.toml
+++ b/ical-relay/config/config.toml
@@ -4,7 +4,7 @@ loglevel = "debug"
 
 [profiles]
   [profiles.du4lcombined]
-    url = "http://front/calendar.ics?key=27b4baf492e1dadd5f525e4ca04dbaf8"
+    url = "http://api:3000/calendar.ics?key=27b4baf492e1dadd5f525e4ca04dbaf8"
     regex = [""]
     public = true
     from = "2021-12-02T00:00:00Z"

--- a/ical-relay/config/config.toml
+++ b/ical-relay/config/config.toml
@@ -1,0 +1,13 @@
+[server]
+addr = ":8080"
+loglevel = "debug"
+
+[profiles]
+  [profiles.du4lcombined]
+    url = "http://front/calendar.ics?key=27b4baf492e1dadd5f525e4ca04dbaf8"
+    regex = [""]
+    public = true
+    from = "2021-12-02T00:00:00Z"
+    until = "2021-12-31T00:00:00Z"
+    passid = true
+    addurl = ["https://outlook.live.com/owa/calendar/00000000-0000-0000-0000-000000000000/d8c3ea1e-74f4-4920-8b55-6166e4c9f57e/cid-DB8463EC38A495B6/calendar.ics"]

--- a/ical-relay/config/config.toml
+++ b/ical-relay/config/config.toml
@@ -4,10 +4,10 @@ loglevel = "debug"
 
 [profiles]
   [profiles.du4lcombined]
-    url = "http://api:3000/calendar.ics?key=27b4baf492e1dadd5f525e4ca04dbaf8"
+    url = "http://api:3000/calendar.ics"
     regex = [""]
     public = true
-    from = "2021-12-02T00:00:00Z"
-    until = "2021-12-31T00:00:00Z"
+    from = "1970-01-01T00:00:00Z"
+    until = "1970-01-01T01:00:00Z"
     passid = true
-    addurl = ["https://outlook.live.com/owa/calendar/00000000-0000-0000-0000-000000000000/d8c3ea1e-74f4-4920-8b55-6166e4c9f57e/cid-DB8463EC38A495B6/calendar.ics"]
+    addurl = ["https://your.external-calendar.org/owa/calendar.ics"]


### PR DESCRIPTION
This adds an endpoint on port 48080 /profiles/du4lcombined that combines the calendar from front and our Outlook-Admin-Calendar.

Few things I'd like to discuss:

- [x] Hardcoding the key into the config here? Seems like a bad idea and defeating the purpose of the key
- [x] can it somehow be integrated so it doesnt need its own exposed port?

But I also wanted to get a "working good enough" commit out there, so we can get the calendar up as soon as possible.