### PR TITLE
Fix eslint warnings

### DIFF
--- a/api/src/plugins/hedgedocAuth.ts
+++ b/api/src/plugins/hedgedocAuth.ts
@@ -1,158 +1,131 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 // Published under GNU General Public License v3.0 by JJ-8
 // https://github.com/JJ-8/CTFNote/blob/427fa61da7680583043d15914cced72dab574e08/api/src/plugins/hedgedocAuth.ts
 // The full License text can be found here https://github.com/JJ-8/CTFNote/blob/main/LICENSE
 
-import { makeWrapResolversPlugin, gql } from "graphile-utils";
+import { makeWrapResolversPlugin } from "graphile-utils";
 import axios from "axios";
-import savepointWrapper from "./savepointWrapper";
 import querystring from "querystring";
 
 export class HedgedocAuth {
-	private static async baseUrl(): Promise<string | null> {
-        /*
+  private static async baseUrl(): Promise<string | null> {
+    /*
 		let cleanUrl: string =
 			process.env.CREATE_PAD_URL || "http://hedgedoc:3000/new";
 		cleanUrl = cleanUrl.slice(0, -4); //remove '/new' for clean url
 		return cleanUrl;
         */
-        return "http://hedgedoc:3000"
-	}
+    return "http://hedgedoc:3000";
+  }
 
-	private static async authPad(
-		username: string,
-		password: string,
-		url: URL
-	): Promise<string> {
-		let domain: string;
-		//if domain does not end in '.[tld]', it will be rejected
-		//so we add '.local' manually
-		if (url.hostname.split(".").length == 1) {
-			domain = `${url.hostname}.local`;
-		} else {
-			domain = url.hostname;
-		}
+  private static async authPad(
+    username: string,
+    password: string,
+    url: URL
+  ): Promise<string> {
+    let domain: string;
+    //if domain does not end in '.[tld]', it will be rejected
+    //so we add '.local' manually
+    if (url.hostname.split(".").length == 1) {
+      domain = `${url.hostname}.local`;
+    } else {
+      domain = url.hostname;
+    }
 
-		const email = `${username}@${domain}`;
+    const email = `${username}@${domain}`;
 
-		try {
-			const res = await axios.post(
-				url.toString(),
-				querystring.stringify({
-					email: email,
-					password: password,
-				}),
-				{
-					validateStatus: (status) => status === 302,
-					maxRedirects: 0,
-					timeout: 5000,
-					headers: {
-						"Content-Type": "application/x-www-form-urlencoded",
-					},
-				}
-			);
-			return res.headers["set-cookie"][0];
-		} catch (e) {
-			console.error(e);
-			return "";
-		}
-	}
+    try {
+      const res = await axios.post(
+        url.toString(),
+        querystring.stringify({
+          email: email,
+          password: password,
+        }),
+        {
+          validateStatus: (status) => status === 302,
+          maxRedirects: 0,
+          timeout: 5000,
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+        }
+      );
+      return res.headers["set-cookie"][0];
+    } catch (e) {
+      console.error(e);
+      return "";
+    }
+  }
 
-	static async register(username: string, password: string): Promise<string> {
-		const authUrl = new URL(`${await this.baseUrl()}/register`);
-		return this.authPad(username, password, authUrl);
-	}
+  static async register(username: string, password: string): Promise<string> {
+    const authUrl = new URL(`${await this.baseUrl()}/register`);
+    return this.authPad(username, password, authUrl);
+  }
 
-	static async verifyLogin(cookie: string): Promise<boolean> {
-		const url = new URL(`${await this.baseUrl()}/me`);
+  static async verifyLogin(cookie: string): Promise<boolean> {
+    const url = new URL(`${await this.baseUrl()}/me`);
 
-		try {
-			const res = await axios.get(url.toString(), {
-				validateStatus: (status) => status === 200,
-				maxRedirects: 0,
-				timeout: 5000,
-				headers: {
-					Cookie: cookie,
-				},
-			});
+    try {
+      const res = await axios.get(url.toString(), {
+        validateStatus: (status) => status === 200,
+        maxRedirects: 0,
+        timeout: 5000,
+        headers: {
+          Cookie: cookie,
+        },
+      });
 
-			return res.data.status == "ok";
-		} catch (e) {
-			return false;
-		}
-	}
+      return res.data.status == "ok";
+    } catch (e) {
+      return false;
+    }
+  }
 
-	static async login(username: string, password: string): Promise<string> {
-		const authUrl = new URL(`${await this.baseUrl()}/login`);
-		const result = await this.authPad(username, password, authUrl);
-		const success = await this.verifyLogin(result);
-		if (!success) {
-			//create account for existing users that are not registered to Hedgedoc
-			await this.register(username, password);
-			return this.authPad(username, password, authUrl);
-		} else {
-			return result;
-		}
-	}
+  static async login(username: string, password: string): Promise<string> {
+    const authUrl = new URL(`${await this.baseUrl()}/login`);
+    const result = await this.authPad(username, password, authUrl);
+    const success = await this.verifyLogin(result);
+    if (!success) {
+      //create account for existing users that are not registered to Hedgedoc
+      await this.register(username, password);
+      return this.authPad(username, password, authUrl);
+    } else {
+      return result;
+    }
+  }
 }
 
 const register_wrapper = {
-	async resolve(
-		resolve: any,
-		_source: any,
-		args: any,
-		context: any,
-		_resolveInfo: any
-	) {
-		const result = await resolve();
-		await HedgedocAuth.register(
-			args.input.login,
-			args.input.password
-		);
-		context.setHeader(
-			"set-cookie",
-			await HedgedocAuth.login(
-				args.input.login,
-				args.input.password
-			)
-		);
-		return result;
-	},
-}
+  async resolve(resolve: any, source: any, args: any, context: any, info: any) {
+    const result = await resolve(source, args, context, info);
+    await HedgedocAuth.register(args.input.login, args.input.password);
+    context.setHeader(
+      "set-cookie",
+      await HedgedocAuth.login(args.input.login, args.input.password)
+    );
+    return result;
+  },
+};
 
 export default makeWrapResolversPlugin({
-	Mutation: {
-		changePassword: {
-			async resolve(
-				resolve: any,
-				_source,
-				args,
-				context: any,
-				_resolveInfo
-			) {
-				throw Error("Disabled until further notice.");
-			},
-		},
-		login: {
-			async resolve(
-				resolve: any,
-				_source,
-				args,
-				context: any,
-				_resolveInfo
-			) {
-				const result = await resolve();
-				context.setHeader(
-					"set-cookie",
-					await HedgedocAuth.login(
-						args.input.login,
-						args.input.password
-					)
-				);
-				return result;
-			},
-		},
-		register: register_wrapper,
-		registerWithPassword: register_wrapper,
-		registerWithToken: register_wrapper,
-	},
+  Mutation: {
+    changePassword: {
+      async resolve() {
+        throw Error("Disabled until further notice.");
+      },
+    },
+    login: {
+      async resolve(resolve, source, args, context, info) {
+        const result = await resolve(source, args, context, info);
+        context.setHeader(
+          "set-cookie",
+          await HedgedocAuth.login(args.input.login, args.input.password)
+        );
+        return result;
+      },
+    },
+    register: register_wrapper,
+    registerWithPassword: register_wrapper,
+    registerWithToken: register_wrapper,
+  },
 });

--- a/api/src/plugins/passwordCheck.ts
+++ b/api/src/plugins/passwordCheck.ts
@@ -1,43 +1,50 @@
-import { makeWrapResolversPlugin, } from "graphile-utils";
-import * as crypto from 'crypto';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { makeWrapResolversPlugin } from "graphile-utils";
+import * as crypto from "crypto";
 import axios from "axios";
 
-async function checkPasswordHaveIBeenPwned(password: string){
-    // https://haveibeenpwned.com/API/v3#PwnedPasswords
-    const hash = crypto.createHash("sha1").update(password).digest("hex").toUpperCase();
-    const hash_range = hash.substring(0, 5);
-    const hash_suffix = hash.substring(5);
-    const res = await axios.get(
-        `https://api.pwnedpasswords.com/range/${hash_range}`,
-        {
-            validateStatus: (status: number) => status === 200,
-            maxRedirects: 0,
-            timeout: 5000
-        }
-    );
-    if(res.data.indexOf(hash_suffix) != -1){
-        throw Error("This password has appeared in a data breach before, please choose a different one.");
+async function checkPasswordHaveIBeenPwned(password: string) {
+  // https://haveibeenpwned.com/API/v3#PwnedPasswords
+  const hash = crypto
+    .createHash("sha1")
+    .update(password)
+    .digest("hex")
+    .toUpperCase();
+  const hash_range = hash.substring(0, 5);
+  const hash_suffix = hash.substring(5);
+  const res = await axios.get(
+    `https://api.pwnedpasswords.com/range/${hash_range}`,
+    {
+      validateStatus: (status: number) => status === 200,
+      maxRedirects: 0,
+      timeout: 5000,
     }
+  );
+  if (res.data.indexOf(hash_suffix) != -1) {
+    throw Error(
+      "This password has appeared in a data breach before, please choose a different one."
+    );
+  }
 }
 
 const wrapper = {
-    async resolve(
-        resolve: any,
-        _source: any,
-        args: any,
-        context: any,
-        _resolveInfo: any
-    ) {
-        await checkPasswordHaveIBeenPwned(args.input.password);
-        const result = await resolve();
-        return result;
-    },
+  async resolve(
+    resolve: any,
+    source: any,
+    args: any,
+    context: any,
+    info: any
+  ): Promise<any> {
+    await checkPasswordHaveIBeenPwned(args.input.password);
+    const result = await resolve(source, args, context, info);
+    return result;
+  },
 };
 
 export default makeWrapResolversPlugin({
-	Mutation: {
-		register: wrapper,
-        registerWithToken: wrapper,
-        registerWithPassword: wrapper,
-	},
+  Mutation: {
+    register: wrapper,
+    registerWithToken: wrapper,
+    registerWithPassword: wrapper,
+  },
 });


### PR DESCRIPTION
Some warnings can only be silenced, not fixed because graphile-utils/node8plus itself uses 'any' type for `ResolverWrapperFn`.

Fixes #33 

