### PR TITLE
Fix crash on invalid host header

### DIFF
--- a/api/src/routes/ical.ts
+++ b/api/src/routes/ical.ts
@@ -53,18 +53,17 @@ export function icalRoute(pool: Pool): Handler {
     const ctfs = await getCtfs();
 
     for (const ctf of ctfs) {
-      // I'm not sure if this works in all cases (e.g. if ctfs aren't at /#/ctf/<id> but at /ctfnote/#/ctf/<id>...)
-      const ctf_url = new URL(
-        `/#/ctf/${ctf.id}-${slugify(ctf.title)}/info`,
-        `${req.protocol}://${req.headers.host}`
-      );
+
+      const proto = req.headers["x-forwarded-proto"] || req.protocol;
+      const host = req.headers["x-forwarded-host"] || req.headers.host;
+      const ctf_url = `${proto}://${host}/#/ctf/${ctf.id}-${slugify(ctf.title)}/info`;
 
       cal.createEvent({
         start: ctf.start_time,
         end: ctf.end_time,
         description: ctf.description,
         summary: ctf.title,
-        url: ctf_url.href,
+        url: ctf_url,
       });
     }
 


### PR DESCRIPTION
This also now respects X-Forwared-Host headers for the CTF urls.