### PR TITLE
[Upstream] Limit task creation by access controll

### DIFF
--- a/api/src/plugins/createTask.ts
+++ b/api/src/plugins/createTask.ts
@@ -44,6 +44,16 @@ export default makeExtendSchemaPlugin((build) => {
           { pgClient },
           resolveInfo
         ) => {
+          const {
+            rows: [isAllowed],
+          } = await pgClient.query(`SELECT ctfnote_private.can_play_ctf($1)`, [
+            ctfId,
+          ]);
+
+          if (isAllowed.can_play_ctf !== true) {
+            return {};
+          }
+
           const padPathOrUrl = await createPad();
 
           let padPath: string;


### PR DESCRIPTION
> Now we first evaluate `ctfnote_private.can_play_ctf` before adding a task.
> If it is not true (value can also be `null`), then we do not create
> and add the pad.
> This prevents guests from adding tasks to CTFs they
> are not allowed to participate in.